### PR TITLE
~ don't accuse a quiet Mac of refusing permission

### DIFF
--- a/CoreEQ/App/AppDelegate.swift
+++ b/CoreEQ/App/AppDelegate.swift
@@ -201,8 +201,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             window.delegate = self
             mainWindow = window
         }
+        // `ignoringOtherApps` deliberately, deprecated or not. The replacement,
+        // `NSApp.activate()`, goes through cooperative activation and may simply
+        // decline when another app holds focus — which is every time this is
+        // called, because an accessory app is never frontmost when its status
+        // menu is clicked. Declining leaves the window ordered in but behind
+        // whatever was in front.
         NSApp.activate(ignoringOtherApps: true)
         mainWindow?.makeKeyAndOrderFront(nil)
+        // And if activation is refused anyway, the window is still shown rather
+        // than left underneath: the user asked for it by name.
+        mainWindow?.orderFrontRegardless()
         // Nothing starts out focused.
         //
         // This window is closed by ordering out and reopened by ordering back

--- a/CoreEQ/Audio/AudioDevices.swift
+++ b/CoreEQ/Audio/AudioDevices.swift
@@ -315,6 +315,42 @@ enum AudioDevices {
         outputBufferChannels(of: deviceID).reduce(0, +)
     }
 
+    /// Whether any process other than `excluding` is currently playing audio.
+    ///
+    /// This is what stops a quiet Mac being mistaken for a refused permission.
+    /// A tap that delivers nothing proves nothing on its own — silence is what
+    /// silence sounds like. A tap that delivers nothing *while something else is
+    /// playing* is a tap that is not receiving.
+    static func isAnyProcessPlayingOutput(excluding excluded: AudioObjectID) -> Bool {
+        var listAddress = address(kAudioHardwarePropertyProcessObjectList)
+        var dataSize: UInt32 = 0
+        guard
+            AudioObjectGetPropertyDataSize(
+                AudioObjectID(kAudioObjectSystemObject), &listAddress, 0, nil, &dataSize) == noErr,
+            dataSize > 0
+        else { return false }
+
+        var processes = [AudioObjectID](
+            repeating: 0, count: Int(dataSize) / MemoryLayout<AudioObjectID>.size)
+        guard
+            AudioObjectGetPropertyData(
+                AudioObjectID(kAudioObjectSystemObject), &listAddress, 0, nil, &dataSize,
+                &processes) == noErr
+        else { return false }
+
+        for process in processes where process != excluded {
+            var runningAddress = address(kAudioProcessPropertyIsRunningOutput)
+            var isRunning: UInt32 = 0
+            var size = UInt32(MemoryLayout<UInt32>.size)
+            if AudioObjectGetPropertyData(process, &runningAddress, 0, nil, &size, &isRunning)
+                == noErr, isRunning != 0
+            {
+                return true
+            }
+        }
+        return false
+    }
+
     static func name(of deviceID: AudioDeviceID) -> String? {
         var address = address(kAudioObjectPropertyName)
         var name: Unmanaged<CFString>?

--- a/CoreEQ/Audio/AudioEngine.swift
+++ b/CoreEQ/Audio/AudioEngine.swift
@@ -470,10 +470,16 @@ final class AudioEngine: ObservableObject {
         tapIDs = []
     }
 
-    /// How often to look for the first sample, and how long before saying that
-    /// none has arrived.
+    /// How often to look for the first sample.
     private static let capturePollInterval: TimeInterval = 0.25
-    private static let captureProofTimeout: TimeInterval = 10
+
+    /// How long the tap may deliver nothing *while something else is playing*
+    /// before the engine says it is not capturing.
+    ///
+    /// Short, because the condition is specific: audio is demonstrably flowing
+    /// and none of it is reaching us. Long enough to cover a tap that takes a
+    /// moment to start after the aggregate does.
+    private static let silenceWhilePlayingLimit: TimeInterval = 2
 
     /// Waits for evidence that the tap is delivering, then mutes.
     ///
@@ -485,26 +491,31 @@ final class AudioEngine: ObservableObject {
     /// The engine is rebuilt rather than the live tap being modified. A tap's
     /// description is writable in principle, but a rebuild uses only operations
     /// already proven to work here, and it happens once per session.
-    private func startProvingCapture(elapsed: TimeInterval = 0) {
+    private func startProvingCapture(silentWhilePlaying: TimeInterval = 0) {
         capturePoll?.cancel()
         let work = DispatchWorkItem { [weak self] in
-            guard let self else { return }
-            guard case .running = self.status else { return }
+            guard let self, self.ioProcID != nil, !self.captureProven else { return }
 
-            if self.processor.hasReceivedAudio {
+            let (verdict, silent) = CaptureProof.evaluate(
+                hasReceivedAudio: self.processor.hasReceivedAudio,
+                isAnythingPlaying: AudioDevices.isAnyProcessPlayingOutput(
+                    excluding: self.tapExcludedProcess),
+                silentWhilePlaying: silentWhilePlaying,
+                interval: Self.capturePollInterval,
+                limit: Self.silenceWhilePlayingLimit)
+
+            if verdict == .proven {
                 self.logger.info("Tap is delivering audio; muting and restarting to process it")
                 self.captureProven = true
                 self.start()
                 return
             }
 
-            let waited = elapsed + Self.capturePollInterval
-            guard waited < Self.captureProofTimeout else {
-                // Nothing has arrived. Say so, and leave the audio alone — the
-                // tap is unmuted, so the only thing wrong is that CoreEQ is not
-                // equalizing. This is what a refused permission looks like:
-                // creating the tap succeeded and it captures nothing.
-                self.logger.error("No audio from the tap; leaving it unmuted")
+            if verdict == .notCapturing, self.tapAccess != .denied {
+                // Audio is playing and none of it is reaching the tap. Say so,
+                // and leave the sound alone — the tap is unmuted, so the only
+                // thing wrong is that CoreEQ is not equalizing.
+                self.logger.error("Audio is playing but the tap is silent; leaving it unmuted")
                 self.tapAccess = .denied
                 self.status = .failed(
                     summary: "Not capturing audio",
@@ -512,12 +523,20 @@ final class AudioEngine: ObservableObject {
                         "CoreEQ is not receiving any audio, so it is leaving your sound alone "
                         + "rather than replacing it. This is what a refused permission looks "
                         + "like.")
-                return
             }
-            self.startProvingCapture(elapsed: waited)
+            // Kept watching either way. A verdict here is a reading of the
+            // moment, not a sentence: allow the permission and the next sound
+            // proves the tap, which promotes it and clears this.
+            self.startProvingCapture(silentWhilePlaying: silent)
         }
         capturePoll = work
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.capturePollInterval, execute: work)
+    }
+
+    /// Our own audio process object, so our playback is not counted as evidence
+    /// that audio is reaching everything *except* us.
+    private var tapExcludedProcess: AudioObjectID {
+        (try? processObjectID(for: getpid())) ?? AudioObjectID(kAudioObjectUnknown)
     }
 
     // MARK: - Change handling

--- a/CoreEQ/Audio/CaptureProof.swift
+++ b/CoreEQ/Audio/CaptureProof.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Whether a tap has shown it can capture, and what to conclude when it has
+/// not.
+///
+/// Pure, and its own type, because the judgement is the hard part and the
+/// engine it belongs to cannot be reached by a test. Reading a sample and
+/// asking whether anything is playing are three lines of Core Audio each;
+/// deciding what those two facts mean together is where this has been wrong.
+enum CaptureProof {
+
+    enum Verdict: Equatable {
+        /// The tap delivered audio. Mute, and start processing.
+        case proven
+        /// Nothing yet, and nothing to conclude from it.
+        case waiting
+        /// Audio is playing and none of it is arriving.
+        case notCapturing
+    }
+
+    /// - Parameters:
+    ///   - hasReceivedAudio: whether the tap has delivered a non-zero sample.
+    ///   - isAnythingPlaying: whether any *other* process is playing output.
+    ///   - silentWhilePlaying: how long the tap has been silent while something
+    ///     was playing, accumulated across previous evaluations.
+    ///   - interval: how long since the last evaluation.
+    ///   - limit: how long that may go on before saying the tap is not
+    ///     capturing.
+    /// - Returns: the verdict, and the silence to carry into the next
+    ///   evaluation.
+    ///
+    /// Silence on its own is never enough. A quiet Mac is quiet, and an engine
+    /// that reads that as a refused permission accuses people of something they
+    /// did not do — which is what the first version of this did, on every launch
+    /// where nothing happened to be playing. Only silence *while audio is
+    /// demonstrably flowing* means the tap is not receiving, so the clock only
+    /// runs while something is playing and is reset when nothing is.
+    static func evaluate(
+        hasReceivedAudio: Bool,
+        isAnythingPlaying: Bool,
+        silentWhilePlaying: TimeInterval,
+        interval: TimeInterval,
+        limit: TimeInterval
+    ) -> (verdict: Verdict, silentWhilePlaying: TimeInterval) {
+        if hasReceivedAudio {
+            return (.proven, 0)
+        }
+        guard isAnythingPlaying else {
+            return (.waiting, 0)
+        }
+        let silent = silentWhilePlaying + interval
+        return (silent >= limit ? .notCapturing : .waiting, silent)
+    }
+}

--- a/CoreEQ/UI/MenuBar/MenuBarController.swift
+++ b/CoreEQ/UI/MenuBar/MenuBarController.swift
@@ -300,7 +300,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     /// Whatever the warning was about is explained in Settings, not here: this
     /// row can hold about four words before the whole menu grows to its width.
     @objc private func openPermission() {
-        SettingsOpener.shared.open(tab: .general)
+        MenuPresentation.afterMenuCloses { SettingsOpener.shared.open(tab: .general) }
     }
 
     private func headerItem() -> NSMenuItem {
@@ -666,12 +666,13 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         row.setImage(presetBadge(for: profileManager.currentFilters, selected: true))
     }
 
+    /// See `MenuPresentation` for why this is not called directly.
     @objc private func openWindow(_ sender: NSMenuItem) {
-        openMainWindow()
+        MenuPresentation.afterMenuCloses { [weak self] in self?.openMainWindow() }
     }
 
     @objc private func openSettingsItem(_ sender: NSMenuItem) {
-        settingsOpener.open()
+        MenuPresentation.afterMenuCloses { [weak self] in self?.settingsOpener.open() }
     }
 
     @objc private func quit(_ sender: NSMenuItem) {

--- a/CoreEQ/UI/MenuBar/MenuPresentation.swift
+++ b/CoreEQ/UI/MenuBar/MenuPresentation.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Opening a window from a status menu.
+///
+/// A menu item's action runs inside the menu's own tracking loop, and a window
+/// presented from there arrives *behind* other applications: an accessory app is
+/// not frontmost when its menu is clicked, and the activation that would bring
+/// it forward does not reliably take while the menu is still up. The window
+/// orders in regardless, so it appears — just underneath whatever was in front.
+/// Whether it wins is a race with the menu dismissing, which is why the bug is
+/// intermittent.
+///
+/// Deferring by one turn of the run loop lets the menu close first, after which
+/// activation means what it says.
+///
+/// A named operation rather than a bare `DispatchQueue.main.async` at each call
+/// site, because at the call site the deferral looks like indirection for its
+/// own sake and invites being tidied away.
+@MainActor
+enum MenuPresentation {
+
+    /// How the work is deferred. Substituted only by tests, which have no menu
+    /// to wait for and need the timing to be theirs to decide.
+    typealias Schedule = (@escaping @MainActor () -> Void) -> Void
+
+    /// The next turn of the main run loop, by which time the menu has gone.
+    static let afterThisRunLoopTurn: Schedule = { present in
+        DispatchQueue.main.async { MainActor.assumeIsolated(present) }
+    }
+
+    /// Presents once the menu that triggered it has closed.
+    ///
+    /// - Parameters:
+    ///   - schedule: how to defer. The default is the only correct answer
+    ///     outside a test.
+    ///   - present: the presentation. Must not be run synchronously — that is
+    ///     the whole point.
+    static func afterMenuCloses(
+        using schedule: Schedule = afterThisRunLoopTurn,
+        _ present: @escaping @MainActor () -> Void
+    ) {
+        schedule(present)
+    }
+}

--- a/CoreEQ/UI/Settings/SettingsOpener.swift
+++ b/CoreEQ/UI/Settings/SettingsOpener.swift
@@ -59,7 +59,13 @@ final class SettingsOpener {
         SettingsRoute.shared.tab = tab
 
         // An accessory application is not frontmost when its status menu is
-        // clicked, so the window would otherwise open behind whatever is.
+        // clicked, so the window would otherwise open behind whatever is. The
+        // callers that come from a menu defer this past the menu's tracking
+        // loop, where activation does not reliably take.
+        //
+        // `ignoringOtherApps` deliberately: `NSApp.activate()` is cooperative
+        // and can decline while another app holds focus, which is precisely the
+        // situation here.
         NSApp.activate(ignoringOtherApps: true)
 
         guard let openSettings else {

--- a/CoreEQTests/CaptureProofTests.swift
+++ b/CoreEQTests/CaptureProofTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+
+/// Whether a tap has shown it can capture.
+///
+/// The two defects this guards are opposites, and both shipped in this file's
+/// absence. Muting on an unproven tap silenced the Mac while the app reported
+/// success. Concluding from silence alone then accused people of refusing a
+/// permission they had granted, on every launch where nothing was playing.
+struct CaptureProofTests {
+    private let interval: TimeInterval = 0.25
+    private let limit: TimeInterval = 2
+
+    private func evaluate(
+        received: Bool = false, playing: Bool = false, silent: TimeInterval = 0
+    ) -> (verdict: CaptureProof.Verdict, silentWhilePlaying: TimeInterval) {
+        CaptureProof.evaluate(
+            hasReceivedAudio: received, isAnythingPlaying: playing,
+            silentWhilePlaying: silent, interval: interval, limit: limit)
+    }
+
+    // MARK: - Proof
+
+    /// A single sample is the whole proof. Nothing else about the situation
+    /// matters once the tap has delivered.
+    @Test func audioArrivingProvesTheTap() {
+        #expect(evaluate(received: true, playing: false).verdict == .proven)
+        #expect(evaluate(received: true, playing: true).verdict == .proven)
+        #expect(
+            evaluate(received: true, playing: true, silent: 60).verdict == .proven,
+            "a long silence before the first sample is not held against the tap")
+    }
+
+    // MARK: - Silence on a quiet Mac
+
+    /// The defect this file exists for. A Mac with nothing playing is quiet,
+    /// and an engine that reads that as a refusal accuses the user of something
+    /// they did not do.
+    @Test func silenceWithNothingPlayingIsNeverAVerdict() {
+        var silent: TimeInterval = 0
+        // Four minutes of a quiet Mac, at four evaluations a second.
+        for _ in 0..<960 {
+            let result = evaluate(playing: false, silent: silent)
+            #expect(result.verdict == .waiting, "a quiet Mac was read as a refusal")
+            silent = result.silentWhilePlaying
+        }
+    }
+
+    /// And the clock does not run while nothing is playing, so silence cannot
+    /// accumulate in the background and convict on the first note.
+    @Test func theClockIsResetWhenNothingIsPlaying() {
+        let nearlyThere = evaluate(playing: true, silent: limit - interval * 2)
+        #expect(nearlyThere.verdict == .waiting)
+
+        let paused = evaluate(playing: false, silent: nearlyThere.silentWhilePlaying)
+        #expect(paused.silentWhilePlaying == 0, "silence accrued while playing was kept")
+
+        let resumed = evaluate(playing: true, silent: paused.silentWhilePlaying)
+        #expect(resumed.verdict == .waiting, "the first moment of playback convicted the tap")
+    }
+
+    // MARK: - Silence while something is playing
+
+    /// Audio flowing and none of it arriving is the one situation that means
+    /// the tap is not receiving.
+    @Test func silenceWhilePlayingEventuallyConcludes() {
+        var silent: TimeInterval = 0
+        var verdicts: [CaptureProof.Verdict] = []
+        for _ in 0..<Int(limit / interval) {
+            let result = evaluate(playing: true, silent: silent)
+            verdicts.append(result.verdict)
+            silent = result.silentWhilePlaying
+        }
+
+        #expect(verdicts.last == .notCapturing, "playing audio never reached a verdict")
+        #expect(
+            verdicts.dropLast().allSatisfy { $0 == .waiting },
+            "the verdict came before the limit")
+    }
+
+    /// Just under the limit is still not enough.
+    @Test func theLimitIsNotReachedEarly() {
+        #expect(evaluate(playing: true, silent: limit - interval * 2).verdict == .waiting)
+    }
+
+    /// And once it is reached it stays reached, so the engine can keep polling
+    /// without the verdict flickering.
+    @Test func theVerdictHoldsWhileTheSilenceContinues() {
+        let past = evaluate(playing: true, silent: limit * 4)
+
+        #expect(past.verdict == .notCapturing)
+        #expect(past.silentWhilePlaying > limit)
+    }
+
+    // MARK: - The guarantee
+
+    /// Restated as one property: nothing but a sample can prove the tap, and
+    /// nothing but audible evidence can condemn it.
+    @Test(arguments: [0.0, 1.0, 10.0, 600.0])
+    func onlyPlaybackCanCondemnATap(silent: TimeInterval) {
+        #expect(evaluate(playing: false, silent: silent).verdict != .notCapturing)
+    }
+}

--- a/CoreEQTests/MenuPresentationTests.swift
+++ b/CoreEQTests/MenuPresentationTests.swift
@@ -1,0 +1,54 @@
+import Testing
+
+/// Opening a window from a status menu.
+///
+/// What is testable here is the contract, not the AppKit behaviour behind it:
+/// that the presentation is *deferred* rather than run where the caller stands.
+/// That is exactly what regressed — the menu action called straight through,
+/// inside the menu's tracking loop, and the window opened behind other apps
+/// whenever the menu had not finished closing.
+///
+/// The deferral reads like indirection for its own sake at the call site. These
+/// tests are what makes removing it fail loudly rather than intermittently.
+@MainActor
+struct MenuPresentationTests {
+
+    /// The rule, stated once: never synchronously.
+    @Test func aPresentationIsNotRunWhereItIsAskedFor() {
+        var presented = false
+
+        MenuPresentation.afterMenuCloses(using: { _ in }, { presented = true })
+
+        #expect(
+            presented == false,
+            "presented inside the menu's tracking loop, where activation does not take")
+    }
+
+    /// And it is not merely dropped.
+    @Test func aPresentationRunsOnceTheMenuHasClosed() {
+        var deferred: (@MainActor () -> Void)?
+        var presented = false
+
+        MenuPresentation.afterMenuCloses(using: { deferred = $0 }, { presented = true })
+        #expect(presented == false)
+
+        deferred?()
+
+        #expect(presented == true, "the presentation was deferred and then never run")
+    }
+
+    /// Each call defers its own work, so two menu items opening two windows do
+    /// not collapse into one.
+    @Test func everyPresentationIsDeferredSeparately() {
+        var deferred: [@MainActor () -> Void] = []
+        var opened: [String] = []
+
+        let collect: MenuPresentation.Schedule = { deferred.append($0) }
+        MenuPresentation.afterMenuCloses(using: collect, { opened.append("window") })
+        MenuPresentation.afterMenuCloses(using: collect, { opened.append("settings") })
+
+        #expect(deferred.count == 2)
+        for present in deferred { present() }
+        #expect(opened == ["window", "settings"])
+    }
+}

--- a/README.org
+++ b/README.org
@@ -201,7 +201,9 @@ preset, and the on/off state are restored on every launch, per output device.
 * Development
 
 Architecture notes, build and test instructions are in
-[[file:docs/DEVELOPMENT.org][docs/DEVELOPMENT.org]].
+[[file:docs/DEVELOPMENT.org][docs/DEVELOPMENT.org]]. What has been fixed is in
+[[file:docs/RELEASE_NOTES.org][docs/RELEASE_NOTES.org]], and what is still owed is in
+[[file:docs/ROADMAP.org][docs/ROADMAP.org]].
 
 #+begin_src sh
 make build   # build the Release configuration

--- a/docs/DEVELOPMENT.org
+++ b/docs/DEVELOPMENT.org
@@ -497,11 +497,19 @@ is the worst state this engine has.
 Unmuted, the same refusal costs only that the audio is not equalized. That is
 how an equalizer should fail, and it is why the order matters: prove, then mute.
 
-The proof is polled every 250 ms and gives up after ten seconds, at which point
-the engine says it is not capturing and *leaves the audio alone*. Returning to
-the app after a refusal starts a fresh attempt, which is how allowing the
-permission in System Settings takes effect — audio capture has no permission API
-to consult, so coming back is the only signal available.
+The proof is polled every 250 ms and never gives up on a clock. Silence proves
+nothing on its own — a quiet Mac is quiet — so the engine waits, indefinitely and
+harmlessly, because an unmuted tap writing nothing is CoreEQ not being there. It
+concludes only when audio is demonstrably flowing and none of it is arriving:
+two seconds of silence *while another process is playing output*
+(=kAudioProcessPropertyIsRunningOutput=, our own process excluded). Then it says
+it is not capturing and *leaves the audio alone*.
+
+It keeps watching after that. A verdict is a reading of the moment rather than a
+sentence, so allowing the permission in System Settings takes effect on the next
+sound, which proves the tap and clears the failure. Returning to the app also
+starts a fresh attempt — audio capture has no permission API to consult, so a
+sound arriving and the app being activated are the only two signals there are.
 
 =EQProcessor.hasReceivedAudio= is the observation, and it is reported in
 Settings ▸ Diagnostics alongside whether the tap is muting yet. The two have to

--- a/docs/RELEASE_NOTES.org
+++ b/docs/RELEASE_NOTES.org
@@ -1,0 +1,178 @@
+#+TITLE: CoreEQ Release Notes
+#+SUBTITLE: What shipped, and what it cost to find
+#+AUTHOR: Andrey Pudov
+#+OPTIONS: toc:2 num:nil
+
+What has actually been fixed, moved here out of [[file:ROADMAP.org][ROADMAP.org]] as it lands. The
+roadmap is what is still owed; this is what has been paid.
+
+Each entry keeps the diagnosis rather than reducing itself to a line of
+changelog. Two of the defects below were never reported by anyone: they were
+found while chasing a third, and both had the same shape — a completely silent
+Mac with every layer of the app reporting that it worked. A fix is easy to
+summarise; how something managed to look healthy while producing no sound is the
+part worth having written down.
+
+* 1.8 — Make it work everywhere it claims to
+
+Not yet released.
+
+** Aggregate and Multi-Output Devices silence the Mac
+
+Found while trying to reproduce the multichannel reports below rather than from
+public feedback — which probably means it has been silencing people who had no
+way to work out what to blame.
+
+Core Audio will not nest one aggregate device inside another, and it does not
+say so. Handed an Aggregate or Multi-Output Device as a sub-device,
+=AudioHardwareCreateAggregateDevice= returns =noErr= and silently drops it,
+leaving an aggregate with no active sub-devices and no output streams at all.
+=AudioDeviceStart= then succeeds on that empty device, the engine reports
+=running=, and the IO proc is handed real tapped audio together with an output
+buffer list of zero buffers. =EQProcessor.render= iterates over nothing. Every
+stage succeeds and no audio is ever written.
+
+The tap, meanwhile, goes on muting every other process at the hardware. So the
+result is a completely silent Mac, an app reporting that it is processing audio,
+and no recovery from inside the app — global bypass skips the DSP without
+releasing the tap, so quitting CoreEQ is the only fix. That is not a
+discoverable one for a menu bar app that can launch at login.
+
+Measured rather than inferred. The same call, wrapping two different devices:
+the built-in speakers give an aggregate with =1 buffer(s) [2ch]= and one active
+sub-device; an Aggregate Device gives =0 buffer(s) []= and zero active
+sub-devices. Both return =noErr=.
+
+This is plausibly a wider fault than the multichannel one it was found under.
+Aggregate and Multi-Output Devices are how people play to two sets of speakers
+at once, and how anyone recording through BlackHole or Loopback is set up, which
+is a larger population than 7.1 HDMI users.
+
+*Fixed.* CoreEQ refuses an aggregate default output before the tap is created,
+so the machine is never muted for a configuration the app cannot serve, and it
+says which device and why. A second check confirms the aggregate it built
+reports output channels before an IO proc is started on it, because a call
+returning =noErr= is evidently not evidence that the device works. Refusing is
+not the same as supporting, which is below under "Later".
+
+** Multichannel outputs
+
+*Configurations reported:* HDMI to a display, an iConnectivity Audio4C over USB,
+and a DisplayPort monitor output raised pre-emptively by someone who had been
+burned before. Reports arrived through both Reddit and GitHub issues and may
+overlap, so treat the count of people as unknown; the count of distinct broken
+setups is what matters and it is at least three.
+
+Symptoms are silence or badly mangled audio, and they persist at Flat, which is
+the tell: the audio still crosses the tap when it is not being filtered, so the
+fault is in the plumbing rather than the DSP.
+
+One Audio4C report adds a detail worth having: “I can hear it over my speakers
+for a split second and then it's gone.” Audio starts and then stops, rather
+than never starting, which points at the moment the aggregate device is built
+and the IO proc takes over rather than at the tap's creation.
+
+CoreEQ takes a stereo tap while the device presents more than two channels, so
+the layout does not line up. Forcing the device to 2 channels in Audio MIDI
+Setup restores sound, which confirms the diagnosis.
+
+Two things to do, and they are probably one change:
+
+- Handle devices with more than two channels honestly. Either match the tap to
+  the device's channel count, or place the stereo pair correctly in a wider
+  layout and pass the rest through untouched. The second is the smaller change
+  and is what the app already claims to do.
+- Stop assuming buffer position. =EQProcessor.render= pairs input buffer /i/
+  with output buffer /i/ across the =AudioBufferList=. That is better than
+  hardcoding buffer 0, but it is still positional, and a developer who shipped
+  the same kind of tool reported the aggregate handing them lists where the
+  tap's buffers were not the first entries. Select by matching channel count
+  and format instead.
+
+*Done when* the three reported configurations produce correct stereo, and a
+device reporting more than two channels either works or is reported in the UI
+rather than failing silently.
+
+*Done.* =EQProcessor= takes an explicit output layout, worked out once on the
+main thread from the device's streams and the taps' formats, and places each
+tap channel at a named output channel instead of pairing buffers by position. A
+tap is bound to every output stream the device presents, because a tap binds to
+one stream and takes that stream's format — binding to the widest alone captured
+two channels of sixteen on an interface presenting eight stereo streams. The
+chain runs on every routed channel with its own delay lines.
+
+Confirmed on hardware, against a sixteen channel device:
+
+- The device-bound tap delivers sixteen channels of 32-bit float, not a stereo
+  mixdown.
+- The aggregate built around it presents sixteen output channels, and the
+  device's own input buffers are accounted for — the tap is not buffer zero on a
+  duplex device.
+- Six channel content arrives as six discrete channels and is placed one to one,
+  with the remaining ten silent.
+- Flat is bit-exact. A +12 dB bell measures +12.0 dB.
+- Driving six channels with six different tones, each channel's measured
+  response matched the drawn curve to within 0.01 dB — which is only true if the
+  chain runs per channel with per-channel state.
+
+What remains untested on hardware is the per-stream path itself: every device
+available here presents a single output stream, so one-tap-per-stream is covered
+by unit tests against a fake tap factory rather than by a real interface.
+
+** Permission text before the system prompt, not after
+
+“System Audio Recording” sounds broader than what an equalizer does, and the
+one moment where that matters is the moment macOS asks. The explanation lived in
+Settings under the permission status, so it was only reachable after the dialog
+had already been answered.
+
+*Done*, and not the way this item imagined. The explanation belongs in
+=NSAudioCaptureUsageDescription=: macOS shows that string inside the permission
+dialog, which is precisely the moment in question. An in-app screen shown before
+the prompt was built first and then removed — it duplicated what the system
+already does, and required the app to predict whether a prompt was coming, which
+macOS gives no way to know.
+
+Two things were learned on the way, both worth keeping written down.
+
+The permission a process tap needs is *audio capture*, declared with
+=NSAudioCaptureUsageDescription= — Apple's own tap sample declares that key and
+nothing else. It is not screen recording, and
+=CGPreflightScreenCaptureAccess= reports a different permission entirely, even
+though the two appear under one heading in System Settings.
+
+And there is no API to ask whether audio capture is allowed. Microphone and
+camera have =AVCaptureDevice.authorizationStatus=; screen recording has a
+preflight; taps have neither, and creating one is what raises the prompt. So an
+app cannot check first — it can only try, and watch what happens.
+
+That last point turned out to matter more than the text did. See the item below.
+
+** Refusing permission silenced the Mac
+
+=AudioHardwareCreateProcessTap= returns *success* when the user has refused
+permission. The tap reports a plausible format, the aggregate runs, the IO proc
+fires — and every sample is zero, while =muteBehavior = .mutedWhenTapped=
+silences every other process at the hardware.
+
+Measured rather than inferred: with a refusal recorded and music playing, the
+engine reported =status: running=, a two channel device-bound tap, and
+=capturing: no audio seen since the engine started=. Apple's tap sample ignores
+the =OSStatus= from that call entirely, so it would behave the same way.
+
+The result was the worst state this engine has: a completely silent Mac, with
+every layer of the app reporting that it works, and nothing on screen.
+
+*Fixed.* Muting is now earned. A tap starts unmuted and the render path writes
+nothing until the engine has seen a non-zero sample; only then does it rebuild
+muted and begin processing. A refusal now costs only that the audio is not
+equalized, which is how an equalizer should fail, and the app says so and offers
+the System Settings pane rather than a retry that cannot help.
+
+The second half of the fix is knowing when *not* to say it. The first attempt
+gave up after ten seconds of silence, which meant launching on a quiet Mac —
+much the commonest way to launch — accused the user of refusing a permission
+they had granted. Silence is not evidence. The engine now waits indefinitely,
+which costs nothing while the tap is unmuted, and concludes only when audio is
+demonstrably playing elsewhere and none of it is arriving. It also keeps
+watching afterwards, so a verdict corrects itself the moment a sample appears.

--- a/docs/ROADMAP.org
+++ b/docs/ROADMAP.org
@@ -17,168 +17,21 @@ Dates are deliberately absent. This is a project I wrote for myself and put on
 GitHub because it turned out to be useful to other people; the order is a
 commitment, the schedule is not.
 
+What is already fixed moves to [[file:RELEASE_NOTES.org][RELEASE_NOTES.org]] rather than staying here marked
+done. This document is what is still owed, so that its length means something.
+
 * 1.8 — Make it work everywhere it claims to
 
-Public feedback produced three defects that are not edge cases. One stops audio
-entirely on USB interfaces and display-connected outputs. One doubles the audio
-and breaks every screen capture tool. One keeps the Mac awake indefinitely.
-Reproducing the first turned up a fourth that nobody reported: an Aggregate or
-Multi-Output Device as the system output silences the Mac outright while the app
-reports that it is working. All four affect people doing nothing unusual, and
-none of them can be worked around from inside the app. Nothing else ships until
-they are fixed.
+Public feedback produced three defects that are not edge cases, and chasing the
+first turned up two more that nobody had reported. Three of the five are fixed
+and have moved to [[file:RELEASE_NOTES.org][RELEASE_NOTES.org]]: audio broken on multichannel outputs, an
+Aggregate or Multi-Output Device silencing the Mac outright, and a refused
+permission doing the same while every layer of the app reported success.
 
-** Aggregate and Multi-Output Devices silence the Mac
-
-Found while trying to reproduce the multichannel reports below rather than from
-public feedback — which probably means it has been silencing people who had no
-way to work out what to blame.
-
-Core Audio will not nest one aggregate device inside another, and it does not
-say so. Handed an Aggregate or Multi-Output Device as a sub-device,
-=AudioHardwareCreateAggregateDevice= returns =noErr= and silently drops it,
-leaving an aggregate with no active sub-devices and no output streams at all.
-=AudioDeviceStart= then succeeds on that empty device, the engine reports
-=running=, and the IO proc is handed real tapped audio together with an output
-buffer list of zero buffers. =EQProcessor.render= iterates over nothing. Every
-stage succeeds and no audio is ever written.
-
-The tap, meanwhile, goes on muting every other process at the hardware. So the
-result is a completely silent Mac, an app reporting that it is processing audio,
-and no recovery from inside the app — global bypass skips the DSP without
-releasing the tap, so quitting CoreEQ is the only fix. That is not a
-discoverable one for a menu bar app that can launch at login.
-
-Measured rather than inferred. The same call, wrapping two different devices:
-the built-in speakers give an aggregate with =1 buffer(s) [2ch]= and one active
-sub-device; an Aggregate Device gives =0 buffer(s) []= and zero active
-sub-devices. Both return =noErr=.
-
-This is plausibly a wider fault than the multichannel one it was found under.
-Aggregate and Multi-Output Devices are how people play to two sets of speakers
-at once, and how anyone recording through BlackHole or Loopback is set up, which
-is a larger population than 7.1 HDMI users.
-
-*Fixed.* CoreEQ refuses an aggregate default output before the tap is created,
-so the machine is never muted for a configuration the app cannot serve, and it
-says which device and why. A second check confirms the aggregate it built
-reports output channels before an IO proc is started on it, because a call
-returning =noErr= is evidently not evidence that the device works. Refusing is
-not the same as supporting, which is below under "Later".
-
-** Multichannel outputs
-
-*Configurations reported:* HDMI to a display, an iConnectivity Audio4C over USB,
-and a DisplayPort monitor output raised pre-emptively by someone who had been
-burned before. Reports arrived through both Reddit and GitHub issues and may
-overlap, so treat the count of people as unknown; the count of distinct broken
-setups is what matters and it is at least three.
-
-Symptoms are silence or badly mangled audio, and they persist at Flat, which is
-the tell: the audio still crosses the tap when it is not being filtered, so the
-fault is in the plumbing rather than the DSP.
-
-One Audio4C report adds a detail worth having: “I can hear it over my speakers
-for a split second and then it's gone.” Audio starts and then stops, rather
-than never starting, which points at the moment the aggregate device is built
-and the IO proc takes over rather than at the tap's creation.
-
-CoreEQ takes a stereo tap while the device presents more than two channels, so
-the layout does not line up. Forcing the device to 2 channels in Audio MIDI
-Setup restores sound, which confirms the diagnosis.
-
-Two things to do, and they are probably one change:
-
-- Handle devices with more than two channels honestly. Either match the tap to
-  the device's channel count, or place the stereo pair correctly in a wider
-  layout and pass the rest through untouched. The second is the smaller change
-  and is what the app already claims to do.
-- Stop assuming buffer position. =EQProcessor.render= pairs input buffer /i/
-  with output buffer /i/ across the =AudioBufferList=. That is better than
-  hardcoding buffer 0, but it is still positional, and a developer who shipped
-  the same kind of tool reported the aggregate handing them lists where the
-  tap's buffers were not the first entries. Select by matching channel count
-  and format instead.
-
-*Done when* the three reported configurations produce correct stereo, and a
-device reporting more than two channels either works or is reported in the UI
-rather than failing silently.
-
-*Done.* =EQProcessor= takes an explicit output layout, worked out once on the
-main thread from the device's streams and the taps' formats, and places each
-tap channel at a named output channel instead of pairing buffers by position. A
-tap is bound to every output stream the device presents, because a tap binds to
-one stream and takes that stream's format — binding to the widest alone captured
-two channels of sixteen on an interface presenting eight stereo streams. The
-chain runs on every routed channel with its own delay lines.
-
-Confirmed on hardware, against a sixteen channel device:
-
-- The device-bound tap delivers sixteen channels of 32-bit float, not a stereo
-  mixdown.
-- The aggregate built around it presents sixteen output channels, and the
-  device's own input buffers are accounted for — the tap is not buffer zero on a
-  duplex device.
-- Six channel content arrives as six discrete channels and is placed one to one,
-  with the remaining ten silent.
-- Flat is bit-exact. A +12 dB bell measures +12.0 dB.
-- Driving six channels with six different tones, each channel's measured
-  response matched the drawn curve to within 0.01 dB — which is only true if the
-  chain runs per channel with per-channel state.
-
-What remains untested on hardware is the per-stream path itself: every device
-available here presents a single output stream, so one-tap-per-stream is covered
-by unit tests against a fake tap factory rather than by a real interface.
-
-** Permission text before the system prompt, not after
-
-“System Audio Recording” sounds broader than what an equalizer does, and the
-one moment where that matters is the moment macOS asks. The explanation lived in
-Settings under the permission status, so it was only reachable after the dialog
-had already been answered.
-
-*Done*, and not the way this item imagined. The explanation belongs in
-=NSAudioCaptureUsageDescription=: macOS shows that string inside the permission
-dialog, which is precisely the moment in question. An in-app screen shown before
-the prompt was built first and then removed — it duplicated what the system
-already does, and required the app to predict whether a prompt was coming, which
-macOS gives no way to know.
-
-Two things were learned on the way, both worth keeping written down.
-
-The permission a process tap needs is *audio capture*, declared with
-=NSAudioCaptureUsageDescription= — Apple's own tap sample declares that key and
-nothing else. It is not screen recording, and
-=CGPreflightScreenCaptureAccess= reports a different permission entirely, even
-though the two appear under one heading in System Settings.
-
-And there is no API to ask whether audio capture is allowed. Microphone and
-camera have =AVCaptureDevice.authorizationStatus=; screen recording has a
-preflight; taps have neither, and creating one is what raises the prompt. So an
-app cannot check first — it can only try, and watch what happens.
-
-That last point turned out to matter more than the text did. See the item below.
-
-** Refusing permission silenced the Mac
-
-=AudioHardwareCreateProcessTap= returns *success* when the user has refused
-permission. The tap reports a plausible format, the aggregate runs, the IO proc
-fires — and every sample is zero, while =muteBehavior = .mutedWhenTapped=
-silences every other process at the hardware.
-
-Measured rather than inferred: with a refusal recorded and music playing, the
-engine reported =status: running=, a two channel device-bound tap, and
-=capturing: no audio seen since the engine started=. Apple's tap sample ignores
-the =OSStatus= from that call entirely, so it would behave the same way.
-
-The result was the worst state this engine has: a completely silent Mac, with
-every layer of the app reporting that it works, and nothing on screen.
-
-*Fixed.* Muting is now earned. A tap starts unmuted and the render path writes
-nothing until the engine has seen a non-zero sample; only then does it rebuild
-muted and begin processing. A refusal now costs only that the audio is not
-equalized, which is how an equalizer should fail, and the app says so and offers
-the System Settings pane rather than a retry that cannot help.
+What is left here: audio arriving twice and every screen capture tool failing, a
+Mac kept awake indefinitely, and two smaller reports. They affect people doing
+nothing unusual, none can be worked around from inside the app, and nothing else
+ships until they are fixed.
 
 ** Bluetooth noise at higher volume
 


### PR DESCRIPTION
Follow-up to #7, which left a hole: the capture proof gave up after ten seconds
of silence and declared the permission refused. Launching with nothing playing —
much the commonest way to launch — therefore accused the user of refusing a
permission they had granted, and then stopped polling, so playing music
afterwards did not fix it.

Silence is not evidence. A quiet Mac is quiet.

## The proof now waits for evidence, not a clock

- It waits indefinitely while nothing is playing. That costs nothing: the tap is
  unmuted and the render path writes nothing, so CoreEQ is effectively not
  there.
- It concludes only when audio is demonstrably flowing and none of it arrives —
  two seconds of silence *while another process is playing output*
  (`kAudioProcessPropertyIsRunningOutput`, our own process excluded).
- It keeps watching afterwards, so a verdict corrects itself: allow the
  permission and the next sound proves the tap and clears the failure.

The judgement moved into `CaptureProof`, pure and testable — the Core Audio
calls are three lines each, and the deciding is what has been wrong twice.
Seven tests, including four simulated minutes of a quiet Mac asserting no
verdict is ever reached, and a parameterised guarantee that silence alone can
never condemn a tap.

## Window opening behind other apps

Two separate causes, both fixed:

- A menu item's action runs inside the menu's tracking loop, and activation
  requested there does not reliably take. Presentation is deferred one run loop
  turn, via a named `MenuPresentation.afterMenuCloses` so it cannot be mistaken
  for pointless indirection and removed. Three tests pin that it is never run
  synchronously.
- `NSApp.activate()` — which I had swapped in for the deprecated
  `activate(ignoringOtherApps:)` in #7 — goes through cooperative activation and
  declines while another app holds focus, which is every time a status menu is
  clicked. Reverted, with the reason written down, plus `orderFrontRegardless()`
  so a refused activation still shows the window.

## Docs

New `docs/RELEASE_NOTES.org` holds the four completed 1.8 items with their
diagnoses; `ROADMAP.org` keeps only what is still owed, so its length means
something. README links both.

## Tests

388 passing, up from 375.