### PR TITLE
~ measure the route-change window, and extend the diagnostics report

### DIFF
--- a/CoreEQ/App/EngineStatusBridge.swift
+++ b/CoreEQ/App/EngineStatusBridge.swift
@@ -36,6 +36,11 @@ final class EngineStatusBridge: ObservableObject {
     /// always no.
     var hasReceivedAudio: Bool { engine?.hasReceivedAudio ?? false }
 
+    /// The worst sample-rate window the engine has seen, for the same reason
+    /// and on the same terms: it can only appear after a route change, so a
+    /// snapshot taken at start would always say none.
+    var rateWindow: RateWindow.Measurement? { engine?.rateWindow }
+
     func follow(_ engine: AudioEngine) {
         self.engine = engine
         engine.$status

--- a/CoreEQ/App/EngineStatusBridge.swift
+++ b/CoreEQ/App/EngineStatusBridge.swift
@@ -41,6 +41,13 @@ final class EngineStatusBridge: ObservableObject {
     /// snapshot taken at start would always say none.
     var rateWindow: RateWindow.Measurement? { engine?.rateWindow }
 
+    /// Uptime, restarts and output level, on the same terms: all three are only
+    /// true at the moment a report is drawn, and all three would read as zero
+    /// forever if they came from the snapshot taken when the engine started.
+    var uptime: TimeInterval? { engine?.uptime }
+    var restarts: DiagnosticsReport.Restarts { engine?.restarts ?? DiagnosticsReport.Restarts() }
+    var level: DiagnosticsReport.Level { engine?.level ?? DiagnosticsReport.Level() }
+
     func follow(_ engine: AudioEngine) {
         self.engine = engine
         engine.$status

--- a/CoreEQ/Audio/AudioEngine.swift
+++ b/CoreEQ/Audio/AudioEngine.swift
@@ -107,6 +107,27 @@ final class AudioEngine: ObservableObject {
     /// The widest interval the render path has spent filtering at a rate the
     /// device was not using. Nil when there has been none, which is every
     /// measurement so far.
+    /// How long the current audio path has been up. Nil when it is not.
+    ///
+    /// What gives "no audio seen" its meaning: after three seconds it says
+    /// nothing at all, and after twenty minutes it says a great deal.
+    var uptime: TimeInterval? { startedAt.map { -$0.timeIntervalSinceNow } }
+
+    /// What has made the engine rebuild itself this session.
+    var restarts: DiagnosticsReport.Restarts {
+        DiagnosticsReport.Restarts(
+            count: restartCount,
+            lastReason: lastRestartReason,
+            since: lastRestartAt.map { -$0.timeIntervalSinceNow })
+    }
+
+    /// The loudest thing the chain has produced, and whether any of it did not
+    /// fit.
+    var level: DiagnosticsReport.Level {
+        DiagnosticsReport.Level(
+            peak: processor.peakLevel, clippedSamples: processor.clippedSamples)
+    }
+
     var rateWindow: RateWindow.Measurement? {
         let trace = processor.rateTrace.snapshot()
         return RateWindow.widest(
@@ -155,6 +176,19 @@ final class AudioEngine: ObservableObject {
     private var defaultDeviceListener: AudioObjectPropertyListenerBlock?
     private var sampleRateListener: AudioObjectPropertyListenerBlock?
     private var rateTraceDump: DispatchWorkItem?
+
+    /// When the engine last came up, and what has made it come up again.
+    ///
+    /// Deliberately outside the diagnostics snapshot, which is rebuilt by every
+    /// start and would therefore always report a fresh engine that had never
+    /// restarted. These survive teardown because the question they answer is
+    /// about the session, not about this instance of the audio path: an echo
+    /// after waking, or audio arriving twice, is the shape of a state change
+    /// that left something behind, and a restart is the state change.
+    private var startedAt: Date?
+    private var restartCount = 0
+    private var lastRestartReason: String?
+    private var lastRestartAt: Date?
     private var streamConfigListener: AudioObjectPropertyListenerBlock?
     private var wakeObserver: (any NSObjectProtocol)?
     private var activationObserver: (any NSObjectProtocol)?
@@ -235,6 +269,7 @@ final class AudioEngine: ObservableObject {
         removeSystemObservers()
         teardownEngine()
         diagnostics = nil
+        startedAt = nil
         status = .stopped
     }
 
@@ -303,6 +338,7 @@ final class AudioEngine: ObservableObject {
         processor.isProvingCapture = !captureProven
         if !captureProven { startProvingCapture() }
 
+        startedAt = Date()
         status = .running(deviceName: device.name)
         logger.info("Engine running on \(device.name, privacy: .public)")
     }
@@ -576,6 +612,9 @@ final class AudioEngine: ObservableObject {
 
     private func scheduleRestart(after delay: TimeInterval, reason: String) {
         logger.info("Restart scheduled: \(reason, privacy: .public)")
+        restartCount += 1
+        lastRestartReason = reason
+        lastRestartAt = Date()
         pendingRestart?.cancel()
         let work = DispatchWorkItem { [weak self] in self?.start() }
         pendingRestart = work

--- a/CoreEQ/Audio/AudioEngine.swift
+++ b/CoreEQ/Audio/AudioEngine.swift
@@ -104,6 +104,15 @@ final class AudioEngine: ObservableObject {
     /// looking at.
     var hasReceivedAudio: Bool { processor.hasReceivedAudio }
 
+    /// The widest interval the render path has spent filtering at a rate the
+    /// device was not using. Nil when there has been none, which is every
+    /// measurement so far.
+    var rateWindow: RateWindow.Measurement? {
+        let trace = processor.rateTrace.snapshot()
+        return RateWindow.widest(
+            RateWindow.readings(trace.cycles, ticksPerSecond: RateTrace.ticksPerSecond))
+    }
+
     /// Whether what stands between the user and their equalizer is the
     /// permission, rather than anything about their device.
     ///
@@ -145,6 +154,7 @@ final class AudioEngine: ObservableObject {
 
     private var defaultDeviceListener: AudioObjectPropertyListenerBlock?
     private var sampleRateListener: AudioObjectPropertyListenerBlock?
+    private var rateTraceDump: DispatchWorkItem?
     private var streamConfigListener: AudioObjectPropertyListenerBlock?
     private var wakeObserver: (any NSObjectProtocol)?
     private var activationObserver: (any NSObjectProtocol)?
@@ -431,8 +441,8 @@ final class AudioEngine: ObservableObject {
     /// cannot be fixed by marking the inline closure `@Sendable`: that was
     /// tried, it compiles, and it still traps.
     private nonisolated static func ioBlock(for processor: EQProcessor) -> AudioDeviceIOBlock {
-        { _, input, _, output, _ in
-            processor.render(input: input, output: output)
+        { now, input, _, output, _ in
+            processor.render(input: input, output: output, now: now)
         }
     }
 
@@ -625,12 +635,17 @@ final class AudioEngine: ObservableObject {
     private func installSampleRateListener() {
         var addr = propertyAddress(kAudioDevicePropertyNominalSampleRate)
         let deviceID = aggregateID
-        let block: AudioObjectPropertyListenerBlock = { _, _ in
+        let block: AudioObjectPropertyListenerBlock = { [processor] _, _ in
+            // Marked here rather than after the hop, so the trace shows what the
+            // hop itself costs.
+            processor.rateTrace.mark(.listenerFired)
             Task { @MainActor [weak self] in
                 guard let self, self.aggregateID == deviceID else { return }
                 if let rate = try? self.nominalSampleRate(of: deviceID) {
                     self.processor.setSampleRate(rate)
+                    self.processor.rateTrace.mark(.rateStaged, rate: rate)
                     self.sampleRate = rate
+                    self.scheduleRateTraceDump()
                 }
             }
         }
@@ -640,6 +655,35 @@ final class AudioEngine: ObservableObject {
         } else {
             logger.error("Failed to install sample rate listener: \(status)")
         }
+    }
+
+    /// Logs the trace once the cycles after a rate change have been recorded.
+    ///
+    /// A second, because the far edge of the window is what is being measured
+    /// and it has not happened yet when the listener fires. Cheap to be
+    /// generous: the ring holds about five seconds.
+    private func scheduleRateTraceDump() {
+        rateTraceDump?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            let trace = self.processor.rateTrace.snapshot()
+            let readings = RateWindow.readings(
+                trace.cycles, ticksPerSecond: RateTrace.ticksPerSecond)
+            self.logger.notice("\(RateWindow.summary(readings), privacy: .public)")
+
+            // The full table only when there is something to explain. It runs to
+            // hundreds of rows — too long for os_log, which truncates a message
+            // well short of that — and on every measurement so far there has
+            // been nothing in it worth keeping.
+            guard RateWindow.widest(readings) != nil else { return }
+            let report = RateWindow.report(cycles: trace.cycles, events: trace.events)
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("coreeq-rate-trace.txt")
+            try? report.write(to: url, atomically: true, encoding: .utf8)
+            self.logger.notice("rate trace written to \(url.path, privacy: .public)")
+        }
+        rateTraceDump = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: work)
     }
 
     /// Tries again when the app comes back to the front, but only after a

--- a/CoreEQ/Audio/Capture/DiagnosticsReport.swift
+++ b/CoreEQ/Audio/Capture/DiagnosticsReport.swift
@@ -66,6 +66,16 @@ enum DiagnosticsReport {
         /// engine has seen it deliver audio, so an unmuted tap means CoreEQ is
         /// still proving it can capture — or has concluded that it cannot.
         var isMuting: Bool = false
+        /// The widest interval, if any, in which the filters ran at a rate the
+        /// device was not using.
+        ///
+        /// Measured rather than assumed to be zero. On the hardware tested there
+        /// is no such interval — Core Audio stops the device across a rate
+        /// change, and the new rate is staged long before audio resumes — but
+        /// that rests on a behaviour rather than a documented promise. A machine
+        /// where it does not hold would sound like every band moving during a
+        /// call, and nothing else in this report would show it.
+        var rateWindow: RateWindow.Measurement?
     }
 
     /// How the saved EQ is keyed, which is the fact that settles "my preset did
@@ -142,6 +152,21 @@ enum DiagnosticsReport {
                 "  muting others:   "
                     + (engine.isMuting
                         ? "yes" : "no — not proven able to capture, so audio is left alone"))
+            if let window = engine.rateWindow {
+                lines.append(
+                    String(
+                        format:
+                            "  rate window:     %.0f ms at %.0f Hz while the device ran at %.0f Hz",
+                        window.seconds * 1_000, window.configuredRate, window.observedRate))
+                lines.append(
+                    String(
+                        format:
+                            "                   NOTE: for that long every band was displaced; "
+                            + "a 1 kHz band sat at %.0f Hz.",
+                        window.displacedKilohertzBand))
+            } else {
+                lines.append("  rate window:     none seen")
+            }
             if let routed = engine.routedChannels, engine.destinations.count > routed {
                 lines.append(
                     "                   NOTE: this device presents more channels than CoreEQ "

--- a/CoreEQ/Audio/Capture/DiagnosticsReport.swift
+++ b/CoreEQ/Audio/Capture/DiagnosticsReport.swift
@@ -29,6 +29,37 @@ enum DiagnosticsReport {
         var lfeChannels: [Int] = []
     }
 
+    /// What has made the audio path rebuild itself this session.
+    ///
+    /// Two open reports — an echo after waking from sleep, and audio arriving
+    /// twice — have the shape of a state change that left something behind. The
+    /// state change is a restart, so a report that does not say whether one
+    /// happened cannot distinguish "this is what CoreEQ always does" from "this
+    /// started after the machine woke up".
+    struct Restarts: Equatable {
+        var count: Int = 0
+        /// Why the last one happened, in the engine's own words.
+        var lastReason: String?
+        /// Seconds since it did.
+        var since: TimeInterval?
+    }
+
+    /// What the chain actually produced.
+    ///
+    /// A boosted preset can ask for more headroom than the material has, and
+    /// what comes out is distortion that people report as noise rather than as
+    /// loudness. Neither the app nor the user can tell that from the settings:
+    /// the level arriving at a tap depends on what is playing. So it is
+    /// measured on the way out.
+    struct Level: Equatable {
+        /// Largest magnitude produced since the engine started. Above 1.0 the
+        /// signal did not fit.
+        var peak: Float = 0
+        var clippedSamples: Int = 0
+
+        var isClipping: Bool { clippedSamples > 0 }
+    }
+
     /// What the running engine actually settled on, as opposed to what a device
     /// says it can do. This is the half a command line tool cannot report: it
     /// would have to build its own tap and infer.
@@ -76,6 +107,10 @@ enum DiagnosticsReport {
         /// where it does not hold would sound like every band moving during a
         /// call, and nothing else in this report would show it.
         var rateWindow: RateWindow.Measurement?
+        /// Seconds the current audio path has been up.
+        var uptime: TimeInterval?
+        var restarts = Restarts()
+        var level = Level()
     }
 
     /// How the saved EQ is keyed, which is the fact that settles "my preset did
@@ -125,7 +160,9 @@ enum DiagnosticsReport {
 
         lines.append("Engine")
         if let engine {
-            lines.append("  status:          \(engine.status)")
+            lines.append(
+                "  status:          \(engine.status)"
+                    + (engine.uptime.map { ", up \(describe(duration: $0))" } ?? ""))
             lines.append("  device:          \(engine.deviceName)")
             lines.append("  sample rate:     \(Int(engine.sampleRate)) Hz")
             lines.append(
@@ -152,6 +189,26 @@ enum DiagnosticsReport {
                 "  muting others:   "
                     + (engine.isMuting
                         ? "yes" : "no — not proven able to capture, so audio is left alone"))
+            if engine.restarts.count > 0 {
+                let reason = engine.restarts.lastReason ?? "unknown"
+                let ago = engine.restarts.since.map { ", \(describe(duration: $0)) ago" } ?? ""
+                lines.append(
+                    "  restarts:        \(engine.restarts.count) (last: \(reason)\(ago))")
+            } else {
+                lines.append("  restarts:        none")
+            }
+            lines.append(
+                String(
+                    format: "  peak output:     %.2f%@", engine.level.peak,
+                    engine.level.isClipping
+                        ? " — \(engine.level.clippedSamples) sample(s) clipped" : ", no clipping"))
+            if engine.level.isClipping {
+                lines.append(
+                    "                   NOTE: the chain produces more than fits, which is heard")
+                lines.append(
+                    "                   as distortion rather than loudness. Lower the band "
+                        + "gains or the preamp, or turn on auto gain.")
+            }
             if let window = engine.rateWindow {
                 lines.append(
                     String(
@@ -246,6 +303,25 @@ enum DiagnosticsReport {
         }
 
         return lines.joined(separator: "\n")
+    }
+
+    /// A rough interval, in the units a reader thinks in.
+    ///
+    /// Rounded on purpose. The question these answer is "was this a moment ago
+    /// or has it been running all afternoon", and a figure to the second invites
+    /// a precision that the answer does not have.
+    ///
+    /// Each tier hands over before its own unit starts sounding wrong. Minutes
+    /// are tested *after* rounding, so 3599 seconds becomes an hour rather than
+    /// "60 min" — the unit is chosen by what the number will read as, not by
+    /// what it was before rounding. A Mac left alone for days is ordinary, and
+    /// "72.0 hr" is arithmetic the reader should not have to do.
+    private static func describe(duration seconds: TimeInterval) -> String {
+        if seconds < 90 { return "\(Int(seconds.rounded())) sec" }
+        let minutes = (seconds / 60).rounded()
+        if minutes < 60 { return "\(Int(minutes)) min" }
+        if seconds < 172_800 { return String(format: "%.1f hr", seconds / 3_600) }
+        return String(format: "%.1f days", seconds / 86_400)
     }
 
     /// "tap 0 → 0, tap 1 → 1", or a note when a channel goes nowhere.

--- a/CoreEQ/Audio/Capture/RateTrace.swift
+++ b/CoreEQ/Audio/Capture/RateTrace.swift
@@ -1,0 +1,125 @@
+import Darwin
+import Foundation
+
+/// One IO cycle, as the render thread saw it.
+///
+/// Deliberately raw. Nothing here is a conclusion: the cadence of these records
+/// *is* the device's real sample rate, and working that out is done afterwards,
+/// on the main thread, with hindsight and no deadline.
+struct RateCycle: Equatable {
+    /// `mach_absolute_time` units, taken from the IO proc's own timestamp.
+    var hostTime: UInt64
+    /// The device's sample clock. Zero when Core Audio did not mark it valid.
+    var sampleTime: Double
+    /// Frames the device asked for this cycle.
+    var frames: Int
+    /// The rate the filters were designed for while this cycle ran. The whole
+    /// point of the trace is the interval where this disagrees with the cadence
+    /// of `hostTime`.
+    var configuredRate: Double
+}
+
+/// Something that happened to the rate, and when.
+///
+/// The kind is an enum and not a string on purpose. These are written from the
+/// render thread, and a `String` field would mean a retain on the way in and a
+/// release of whatever it replaced on the way out — ARC traffic on the audio
+/// path, to say something no faster than a tag does. Words are attached later.
+struct RateEvent: Equatable {
+    enum Kind: Equatable {
+        /// Core Audio said the device's nominal rate changed.
+        case listenerFired
+        /// The new rate was read back and staged for the render thread.
+        case rateStaged
+        /// The render thread picked it up. The far edge of the stale window.
+        case coefficientsRecomputed
+    }
+
+    var hostTime: UInt64
+    var kind: Kind
+    /// The rate the event is about, or zero when it is not about one.
+    var rate: Double
+}
+
+/// A flight recorder for sample-rate changes.
+///
+/// A Bluetooth headset moving to its call profile drops the output rate by two
+/// to three times. Coefficients are a function of `2πf/fs`, so until they are
+/// recomputed every band sits at the wrong frequency — a 1 kHz bell lands near
+/// 333 Hz. CoreEQ recomputes them from a property listener, and a listener
+/// necessarily fires *after* the change, so a window exists. Whether it is two
+/// buffers or three hundred milliseconds decides whether it is worth fixing,
+/// and that is not answerable by reading the source.
+///
+/// So this measures rather than decides. The render thread writes one small
+/// record per cycle into a fixed ring and never looks at it; the main thread
+/// marks the moments it knows about; the arithmetic happens later. Building a
+/// detector first would mean choosing thresholds before having any data to
+/// choose them from.
+///
+/// `@unchecked Sendable` on the same terms as `EQProcessor`: one writer on the
+/// render thread, one reader on the main thread, fixed storage allocated up
+/// front, and no lock anywhere on the audio path. A torn record costs one line
+/// of a diagnostic.
+final class RateTrace: @unchecked Sendable {
+
+    /// About five seconds at a 512-frame buffer, which is far longer than any
+    /// route change takes and still only 24 KB.
+    static let capacity = 512
+    private static let eventCapacity = 32
+
+    /// Host ticks per second, from the machine's own timebase — 125/3 on Apple
+    /// silicon, so this cannot be assumed to be nanoseconds.
+    static let ticksPerSecond: Double = {
+        var info = mach_timebase_info_data_t()
+        mach_timebase_info(&info)
+        return 1e9 * Double(info.denom) / Double(info.numer)
+    }()
+
+    nonisolated(unsafe) private var cycles = [RateCycle](
+        repeating: RateCycle(hostTime: 0, sampleTime: 0, frames: 0, configuredRate: 0),
+        count: capacity)
+    nonisolated(unsafe) private var written = 0
+
+    nonisolated(unsafe) private var events = [RateEvent](
+        repeating: RateEvent(hostTime: 0, kind: .listenerFired, rate: 0), count: eventCapacity)
+    nonisolated(unsafe) private var eventsWritten = 0
+
+    /// Called once per IO cycle, on the render thread.
+    ///
+    /// Four stores into storage that already exists. No allocation, no lock, no
+    /// retain: `RateCycle` is trivial, and the array is never resized.
+    func record(hostTime: UInt64, sampleTime: Double, frames: Int, configuredRate: Double) {
+        cycles[written % Self.capacity] = RateCycle(
+            hostTime: hostTime,
+            sampleTime: sampleTime,
+            frames: frames,
+            configuredRate: configuredRate)
+        written &+= 1
+    }
+
+    /// Notes something that happened, from either thread.
+    ///
+    /// Trivial all the way down, so the render thread can call it: two stores
+    /// into storage that already exists, and `mach_absolute_time` is a bare
+    /// register read.
+    func mark(_ kind: RateEvent.Kind, rate: Double = 0, at hostTime: UInt64 = mach_absolute_time())
+    {
+        events[eventsWritten % Self.eventCapacity] = RateEvent(
+            hostTime: hostTime, kind: kind, rate: rate)
+        eventsWritten &+= 1
+    }
+
+    /// Everything still in the ring, oldest first. Main thread.
+    func snapshot() -> (cycles: [RateCycle], events: [RateEvent]) {
+        let cycleCount = min(written, Self.capacity)
+        let cycleStart = written - cycleCount
+        let recorded = (0..<cycleCount).map { cycles[(cycleStart + $0) % Self.capacity] }
+
+        let eventCount = min(eventsWritten, Self.eventCapacity)
+        let eventStart = eventsWritten - eventCount
+        let marked = (0..<eventCount).map { events[(eventStart + $0) % Self.eventCapacity] }
+
+        return (recorded, marked)
+    }
+}

--- a/CoreEQ/Audio/Capture/RateWindow.swift
+++ b/CoreEQ/Audio/Capture/RateWindow.swift
@@ -1,0 +1,199 @@
+import Foundation
+
+/// Reading a `RateTrace` after the fact.
+///
+/// The device's true rate is not something CoreEQ is told in time; it is
+/// something the IO cadence reveals. Frames delivered divided by real time
+/// elapsed *is* the rate, and comparing that against the rate the filters were
+/// built for gives the interval where the two disagreed — the window this
+/// exists to size.
+///
+/// Pure, and separated from the recording for the usual reason: the arithmetic
+/// is the part worth being sure about, and it can be checked against traces
+/// written by hand rather than by a Bluetooth headset.
+enum RateWindow {
+
+    /// How far the observed rate may sit from the configured one before the two
+    /// are called different.
+    ///
+    /// Ten percent is well above IO scheduling jitter and well below the two to
+    /// three times a Bluetooth call profile moves things, so it separates the
+    /// case worth finding from the noise without needing to be exact. It also
+    /// sits above the 44.1 to 48 kHz step (9%), which is deliberate: that change
+    /// puts a 1 kHz band at 1088 Hz, which is not a defect anyone can hear.
+    static let tolerance = 0.10
+
+    /// What one cycle implies about the device's real rate.
+    struct Reading: Equatable {
+        var hostTime: UInt64
+        /// Seconds since the previous cycle.
+        var elapsed: Double
+        /// Frames per second, as the cadence implies.
+        var observedRate: Double
+        /// What the filters were designed for at that moment.
+        var configuredRate: Double
+
+        /// Whether the filters were wrong about the rate for this cycle.
+        var disagrees: Bool {
+            guard configuredRate > 0, observedRate > 0 else { return false }
+            return abs(observedRate / configuredRate - 1) > RateWindow.tolerance
+        }
+    }
+
+    /// An interval where the filters ran at the wrong rate.
+    struct Measurement: Equatable {
+        /// Width of the window.
+        var seconds: Double
+        /// IO cycles filtered with the wrong coefficients.
+        var cycles: Int
+        /// What the filters were built for while it lasted.
+        var configuredRate: Double
+        /// What the device was actually running at.
+        var observedRate: Double
+
+        /// Where a band designed for 1 kHz actually sat during the window.
+        ///
+        /// The number to quote in a report: "37 ms" says nothing on its own,
+        /// "37 ms with every band a third of where it should be" says what the
+        /// user heard.
+        var displacedKilohertzBand: Double {
+            guard configuredRate > 0 else { return 0 }
+            return 1_000 * observedRate / configuredRate
+        }
+    }
+
+    /// Turns raw cycles into per-cycle readings.
+    ///
+    /// The device's own sample clock is used when Core Audio marked it valid,
+    /// since it is exact where a frame count is only nominal; the frame count is
+    /// the fallback. The first cycle yields nothing — a cadence needs two.
+    static func readings(_ cycles: [RateCycle], ticksPerSecond: Double) -> [Reading] {
+        guard ticksPerSecond > 0 else { return [] }
+        var readings: [Reading] = []
+        readings.reserveCapacity(max(0, cycles.count - 1))
+
+        for index in 1..<max(cycles.count, 1) {
+            let previous = cycles[index - 1]
+            let current = cycles[index]
+            let elapsed = Double(current.hostTime &- previous.hostTime) / ticksPerSecond
+            guard elapsed > 0 else { continue }
+
+            let advanced =
+                (current.sampleTime > 0 && previous.sampleTime > 0)
+                ? current.sampleTime - previous.sampleTime
+                : Double(previous.frames)
+            guard advanced > 0 else { continue }
+
+            readings.append(
+                Reading(
+                    hostTime: current.hostTime,
+                    elapsed: elapsed,
+                    observedRate: advanced / elapsed,
+                    configuredRate: current.configuredRate))
+        }
+        return readings
+    }
+
+    /// The widest interval in the trace where the two disagreed.
+    ///
+    /// Widest rather than first: a trace can hold several route changes, and the
+    /// worst one is what decides whether this needs fixing.
+    static func widest(_ readings: [Reading]) -> Measurement? {
+        var widest: Measurement?
+        var start: Reading?
+        var count = 0
+
+        func close(at end: Reading) {
+            guard let opened = start else { return }
+            let seconds = Double(end.hostTime &- opened.hostTime) / RateTrace.ticksPerSecond
+            let measurement = Measurement(
+                seconds: seconds,
+                cycles: count,
+                configuredRate: opened.configuredRate,
+                observedRate: opened.observedRate)
+            if seconds > (widest?.seconds ?? -1) { widest = measurement }
+            start = nil
+            count = 0
+        }
+
+        for reading in readings {
+            if reading.disagrees {
+                if start == nil { start = reading }
+                count += 1
+            } else {
+                close(at: reading)
+            }
+        }
+        // A trace that ends mid-disagreement still measures what it saw.
+        if let last = readings.last, start != nil { close(at: last) }
+
+        return widest
+    }
+
+    /// The trace as a table, for the log.
+    ///
+    /// Every cycle, not a summary: the summary is what is in question, and a
+    /// table is what lets a wrong summary be spotted.
+    static func report(
+        cycles: [RateCycle], events: [RateEvent], ticksPerSecond: Double = RateTrace.ticksPerSecond
+    ) -> String {
+        let readings = readings(cycles, ticksPerSecond: ticksPerSecond)
+        guard let origin = cycles.first?.hostTime else { return "rate trace: empty" }
+
+        // Signed deliberately. Events are marked on the main thread and cycles
+        // on the render thread, into rings of different lengths, so an event can
+        // easily be older than the oldest cycle still held. Unsigned subtraction
+        // turns that into 768614336339369 ms, which reads as a broken clock
+        // rather than as "this happened before the trace begins".
+        func offset(_ hostTime: UInt64) -> Double {
+            (Double(hostTime) - Double(origin)) / ticksPerSecond * 1_000
+        }
+
+        var lines: [String] = [summary(readings)]
+
+        for event in events {
+            lines.append(
+                String(
+                    format: "  %8.2f ms  %@", offset(event.hostTime), describe(event)))
+        }
+
+        lines.append("       t/ms   elapsed/ms   observed/Hz   configured/Hz")
+        for reading in readings {
+            lines.append(
+                String(
+                    format: "  %9.2f %12.3f %13.0f %15.0f%@",
+                    offset(reading.hostTime), reading.elapsed * 1_000, reading.observedRate,
+                    reading.configuredRate, reading.disagrees ? "  <-- stale" : ""))
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// The one line worth logging: what was found, if anything.
+    ///
+    /// Separate from `report` because a trace runs to hundreds of cycles and
+    /// `os_log` truncates a message long before that — the first attempt at
+    /// this logged the whole table and lost exactly the rows being looked for.
+    /// The summary goes to the log, the table goes to a file.
+    static func summary(_ readings: [Reading]) -> String {
+        guard let widest = widest(readings) else {
+            return "rate trace: \(readings.count) cycles, "
+                + "no disagreement beyond \(Int(tolerance * 100))%"
+        }
+        return String(
+            format:
+                "rate trace: %d cycles, WINDOW %.1f ms over %d cycles: "
+                + "configured %.0f Hz, actual %.0f Hz (a 1 kHz band sat at %.0f Hz)",
+            readings.count, widest.seconds * 1_000, widest.cycles, widest.configuredRate,
+            widest.observedRate, widest.displacedKilohertzBand)
+    }
+
+    /// Words for a tag, on the main thread where words are free.
+    static func describe(_ event: RateEvent) -> String {
+        let rate = event.rate > 0 ? " (\(Int(event.rate)) Hz)" : ""
+        switch event.kind {
+        case .listenerFired: return "Core Audio reported a rate change" + rate
+        case .rateStaged: return "new rate staged for the render thread" + rate
+        case .coefficientsRecomputed: return "coefficients recomputed" + rate
+        }
+    }
+}

--- a/CoreEQ/EQ/EQProcessor.swift
+++ b/CoreEQ/EQ/EQProcessor.swift
@@ -77,6 +77,11 @@ final class EQProcessor: @unchecked Sendable {
     /// consumer can snapshot without the producer overtaking the read region.
     let spectrumBuffer = SpectrumAudioBuffer(capacity: 8_192)
 
+    /// Flight recorder for sample-rate changes. Always on: it costs four stores
+    /// a cycle, and the interval it measures is one nobody can reproduce on
+    /// demand — it happens on someone else's headset, once, mid-call.
+    let rateTrace = RateTrace()
+
     /// Where the tap's channels land in the device's output layout.
     ///
     /// `render` used to assume two things that are only true of a plain stereo
@@ -329,11 +334,13 @@ final class EQProcessor: @unchecked Sendable {
     /// channel device fills two channels and silences six, rather than smearing
     /// four frames of stereo across one frame of eight.
     func render(
-        input: UnsafePointer<AudioBufferList>, output: UnsafeMutablePointer<AudioBufferList>
+        input: UnsafePointer<AudioBufferList>, output: UnsafeMutablePointer<AudioBufferList>,
+        now: UnsafePointer<AudioTimeStamp>? = nil
     ) {
         let inABL = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: input))
         let outABL = UnsafeMutableAudioBufferListPointer(output)
 
+        recordCycle(now, outABL)
         consumePendingParameters()
 
         // Silence first, then place. Every output channel the tap does not feed
@@ -562,6 +569,27 @@ final class EQProcessor: @unchecked Sendable {
         for i in 0..<delays.count { delays[i] = 0 }
     }
 
+    /// Notes this cycle's cadence for `RateWindow` to read later.
+    ///
+    /// The frame count comes from the output list rather than from anything the
+    /// tap logic works out, so it is available whatever else the cycle does —
+    /// including while the tap is still being proved and nothing is written.
+    private func recordCycle(
+        _ now: UnsafePointer<AudioTimeStamp>?, _ outABL: UnsafeMutableAudioBufferListPointer
+    ) {
+        guard let now, outABL.count > 0 else { return }
+        let channels = Int(outABL[0].mNumberChannels)
+        guard channels > 0 else { return }
+        let frames = Int(outABL[0].mDataByteSize) / (MemoryLayout<Float>.size * channels)
+
+        let timestamp = now.pointee
+        rateTrace.record(
+            hostTime: timestamp.mHostTime,
+            sampleTime: timestamp.mFlags.contains(.sampleTimeValid) ? timestamp.mSampleTime : 0,
+            frames: frames,
+            configuredRate: sampleRate)
+    }
+
     private func consumePendingParameters() {
         guard lock.lockIfAvailable() else { return }
         // Copied out under the lock into fixed storage the render thread already
@@ -626,6 +654,9 @@ final class EQProcessor: @unchecked Sendable {
         }
 
         if let newRate, newRate != sampleRate {
+            // The far edge of the stale window, and the only place it can be
+            // timed: everything before this point ran on the old coefficients.
+            rateTrace.mark(.coefficientsRecomputed, rate: newRate)
             sampleRate = newRate
             for i in 0..<filterCount {
                 filters[i].needsCoefficientUpdate = true

--- a/CoreEQ/EQ/EQProcessor.swift
+++ b/CoreEQ/EQ/EQProcessor.swift
@@ -72,6 +72,21 @@ final class EQProcessor: @unchecked Sendable {
     /// silence, or one buffer unprocessed.
     nonisolated(unsafe) var isProvingCapture = false
 
+    /// The loudest sample the EQ has produced since the engine started, and how
+    /// many left the representable range.
+    ///
+    /// A boosted preset can ask for more headroom than the signal has, and the
+    /// result is distortion the user hears as noise rather than as loudness —
+    /// two reports of exactly that are open. Nothing else can settle it: the mix
+    /// level arriving at a tap is unknowable from inside it, so the only way to
+    /// know whether CoreEQ is clipping is to look at what CoreEQ produced.
+    ///
+    /// Unsynchronised for the same reasons as `hasReceivedAudio`: written only
+    /// on the render thread, read only for a report, and a reader that catches
+    /// a stale value is a reader who asks again.
+    nonisolated(unsafe) private(set) var peakLevel: Float = 0
+    nonisolated(unsafe) private(set) var clippedSamples = 0
+
     /// Mono copy of the played-back output, tapped for the spectrum analyzer.
     /// 8192 samples is well beyond the analyzer's 4096-sample window, so the
     /// consumer can snapshot without the producer overtaking the read region.
@@ -296,6 +311,8 @@ final class EQProcessor: @unchecked Sendable {
     /// Forgets what the tap has delivered, for a fresh engine.
     func resetAudioObservation() {
         hasReceivedAudio = false
+        peakLevel = 0
+        clippedSamples = 0
     }
 
     /// Stages the output layout. Set by `AudioEngine` once per engine start,
@@ -458,7 +475,31 @@ final class EQProcessor: @unchecked Sendable {
             processChannel(
                 target.pointer, stride: target.stride, frames: count, channel: channel)
             applyPreamp(target.pointer, stride: target.stride, frames: count)
+            measureLevel(target.pointer, stride: target.stride, frames: count)
         }
+    }
+
+    /// Watches what the chain actually produced.
+    ///
+    /// Called only from `equalize`, which is deliberate: bypass passes samples
+    /// through untouched, so there is nothing CoreEQ could have clipped and
+    /// nothing worth the pass. The peak is kept for the life of the engine
+    /// rather than per block — the question is whether this ever happened, and a
+    /// value that decays answers it only for whoever is watching at the time.
+    private func measureLevel(
+        _ samples: UnsafePointer<Float>, stride: Int, frames: Int
+    ) {
+        var peak = peakLevel
+        var clipped = 0
+        var index = 0
+        for _ in 0..<frames {
+            let magnitude = abs(samples[index])
+            if magnitude > peak { peak = magnitude }
+            if magnitude > 1.0 { clipped &+= 1 }
+            index += stride
+        }
+        peakLevel = peak
+        clippedSamples &+= clipped
     }
 
     /// Locates one global output channel: which buffer holds it, where in that

--- a/CoreEQ/UI/Settings/DiagnosticsSettingsView.swift
+++ b/CoreEQ/UI/Settings/DiagnosticsSettingsView.swift
@@ -104,11 +104,11 @@ struct DiagnosticsSettingsView: View {
         )
     }
 
-    /// The engine's snapshot, with the one fact that goes stale refreshed.
+    /// The engine's snapshot, with the facts that go stale refreshed.
     ///
     /// The snapshot is taken when the engine starts, and at that moment the tap
-    /// has by definition delivered nothing. Reporting it from there would say
-    /// "no audio seen" forever.
+    /// has by definition delivered nothing and no route has changed. Reporting
+    /// either from there would say "no audio seen" and "no rate window" forever.
     private static func liveEngine(
         _ snapshot: DiagnosticsReport.Engine?
     )
@@ -116,6 +116,7 @@ struct DiagnosticsSettingsView: View {
     {
         guard var snapshot else { return nil }
         snapshot.hasReceivedAudio = EngineStatusBridge.shared.hasReceivedAudio
+        snapshot.rateWindow = EngineStatusBridge.shared.rateWindow
         return snapshot
     }
 

--- a/CoreEQ/UI/Settings/DiagnosticsSettingsView.swift
+++ b/CoreEQ/UI/Settings/DiagnosticsSettingsView.swift
@@ -117,6 +117,9 @@ struct DiagnosticsSettingsView: View {
         guard var snapshot else { return nil }
         snapshot.hasReceivedAudio = EngineStatusBridge.shared.hasReceivedAudio
         snapshot.rateWindow = EngineStatusBridge.shared.rateWindow
+        snapshot.uptime = EngineStatusBridge.shared.uptime
+        snapshot.restarts = EngineStatusBridge.shared.restarts
+        snapshot.level = EngineStatusBridge.shared.level
         return snapshot
     }
 

--- a/CoreEQTests/Audio/Capture/DiagnosticsReportTests.swift
+++ b/CoreEQTests/Audio/Capture/DiagnosticsReportTests.swift
@@ -246,4 +246,92 @@ struct DiagnosticsReportTests {
         #expect(report.contains("1 kHz band sat at 363 Hz"))
     }
 
+    // MARK: - Output level
+
+    /// The line that settles the open noise reports. Both halves have to be
+    /// unambiguous: a reader who has never seen this report cannot tell a
+    /// missing line from a healthy one.
+    @Test func aChainWithHeadroomToSpareSaysSo() {
+        var quiet = engine()
+        quiet.level = DiagnosticsReport.Level(peak: 0.71, clippedSamples: 0)
+
+        let report = text(engine: quiet)
+
+        #expect(report.contains("peak output:     0.71, no clipping"))
+        #expect(report.contains("NOTE: the chain produces more than fits") == false)
+    }
+
+    /// Clipping is the first hypothesis for "it sounds broken at higher volume",
+    /// and the one thing the user cannot check for themselves — the level
+    /// arriving at a tap depends on what is playing.
+    @Test func aClippingChainIsNamedAndExplained() {
+        var loud = engine()
+        loud.level = DiagnosticsReport.Level(peak: 1.84, clippedSamples: 4_812)
+
+        let report = text(engine: loud)
+
+        #expect(report.contains("1.84"))
+        #expect(report.contains("4812 sample(s) clipped"))
+        #expect(report.contains("as distortion rather than loudness"))
+    }
+
+    /// One sample over is still clipping. A threshold that ignored a handful
+    /// would hide the intermittent case, which is the one people report.
+    @Test func aSingleClippedSampleCounts() {
+        #expect(DiagnosticsReport.Level(peak: 1.0001, clippedSamples: 1).isClipping)
+        #expect(DiagnosticsReport.Level(peak: 1.0, clippedSamples: 0).isClipping == false)
+    }
+
+    // MARK: - Restarts and uptime
+
+    /// "No audio seen" means nothing without knowing for how long.
+    @Test func theReportSaysHowLongTheEngineHasBeenUp() {
+        var running = engine()
+        running.uptime = 754
+
+        #expect(text(engine: running).contains("up 13 min"))
+    }
+
+    @Test func aFreshEngineReportsRestartsAsNone() {
+        #expect(text(engine: engine()).contains("restarts:        none"))
+    }
+
+    /// The wake-from-sleep echo is a report of something that happens after a
+    /// restart, so the reason and the age are the whole point of the line.
+    @Test func aRestartIsNamedWithItsReasonAndAge() {
+        var restarted = engine()
+        restarted.restarts = DiagnosticsReport.Restarts(
+            count: 3, lastReason: "system woke from sleep", since: 240)
+
+        let report = text(engine: restarted)
+
+        #expect(report.contains("restarts:        3"))
+        #expect(report.contains("system woke from sleep"))
+        #expect(report.contains("4 min ago"))
+    }
+
+    /// Durations are rounded to the unit a reader thinks in, and every case here
+    /// is a boundary where the wrong choice reads absurdly. The 3_599 one is the
+    /// reason minutes are tested after rounding rather than before: it used to
+    /// report "60 min", which is not how anyone says an hour.
+    @Test func durationsAreReportedInReadableUnits() {
+        let cases = [
+            (45.0, "up 45 sec"),
+            (89.0, "up 89 sec"),
+            (90.0, "up 2 min"),
+            (600.0, "up 10 min"),
+            (3_540.0, "up 59 min"),
+            (3_599.0, "up 1.0 hr"),
+            (3_600.0, "up 1.0 hr"),
+            (5_400.0, "up 1.5 hr"),
+            (86_400.0, "up 24.0 hr"),
+            (259_200.0, "up 3.0 days"),
+        ]
+        for (seconds, expected) in cases {
+            var running = engine()
+            running.uptime = seconds
+            #expect(text(engine: running).contains(expected), "\(seconds)s read wrongly")
+        }
+    }
+
 }

--- a/CoreEQTests/Audio/Capture/DiagnosticsReportTests.swift
+++ b/CoreEQTests/Audio/Capture/DiagnosticsReportTests.swift
@@ -222,4 +222,28 @@ struct DiagnosticsReportTests {
     @Test func noDevicesIsStatedRatherThanBlank() {
         #expect(text().contains("none found"))
     }
+    // MARK: - The sample-rate window
+
+    /// The quiet case has to say something. "No line" and "a line saying none"
+    /// read identically to someone who does not know the line exists, and this
+    /// report is read by people who have never seen another one.
+    @Test func aReportWithNoRateWindowSaysSo() {
+        #expect(text(engine: engine()).contains("rate window:     none seen"))
+    }
+
+    /// The number that matters is not the duration; it is where the bands went.
+    /// "41 ms" tells a reader nothing they can act on.
+    @Test func aRateWindowNamesWhereTheBandsWent() {
+        var stale = engine()
+        stale.rateWindow = RateWindow.Measurement(
+            seconds: 0.041, cycles: 4, configuredRate: 44_100, observedRate: 16_000)
+
+        let report = text(engine: stale)
+
+        #expect(report.contains("41 ms"))
+        #expect(report.contains("44100 Hz"))
+        #expect(report.contains("16000 Hz"))
+        #expect(report.contains("1 kHz band sat at 363 Hz"))
+    }
+
 }

--- a/CoreEQTests/Audio/Capture/RateWindowTests.swift
+++ b/CoreEQTests/Audio/Capture/RateWindowTests.swift
@@ -1,0 +1,230 @@
+import Foundation
+import Testing
+
+/// Sizing the interval where the filters ran at the wrong sample rate.
+///
+/// The traces here are written by hand precisely because the real ones are not
+/// reproducible on demand — they come off a Bluetooth headset changing profile
+/// mid-call. If the arithmetic that reads them is wrong, the measurement is
+/// worth nothing and there is no way to notice from the output.
+struct RateWindowTests {
+
+    /// A tidy timebase, so a cycle's host-time delta reads as microseconds.
+    private static let ticks = 1_000_000.0
+
+    /// Cycles delivering `frames` at `actualRate`, while the filters believe
+    /// `configuredRate`.
+    private func cycles(
+        count: Int,
+        frames: Int = 512,
+        actualRate: Double,
+        configuredRate: Double,
+        from hostTime: UInt64 = 1_000,
+        sampleTime: Double = 0
+    ) -> [RateCycle] {
+        let step = UInt64((Double(frames) / actualRate) * Self.ticks)
+        return (0..<count).map { index in
+            RateCycle(
+                hostTime: hostTime &+ UInt64(index) &* step,
+                sampleTime: sampleTime > 0 ? sampleTime + Double(index * frames) : 0,
+                frames: frames,
+                configuredRate: configuredRate)
+        }
+    }
+
+    // MARK: - Reading the cadence
+
+    /// The cadence is the rate. Nothing else in the system reports it in time.
+    @Test func theObservedRateComesFromTheCadence() {
+        let readings = RateWindow.readings(
+            cycles(count: 5, actualRate: 48_000, configuredRate: 48_000),
+            ticksPerSecond: Self.ticks)
+
+        #expect(readings.count == 4, "a cadence needs two cycles, so one is spent")
+        for reading in readings {
+            #expect(abs(reading.observedRate - 48_000) < 100)
+            #expect(reading.disagrees == false)
+        }
+    }
+
+    /// The device's own sample clock is used when Core Audio marks it valid,
+    /// because a frame count is only what was asked for.
+    @Test func theSampleClockIsPreferredWhenItIsValid() {
+        let withClock = cycles(
+            count: 4, actualRate: 48_000, configuredRate: 48_000, sampleTime: 900_000)
+        let readings = RateWindow.readings(withClock, ticksPerSecond: Self.ticks)
+
+        #expect(readings.allSatisfy { abs($0.observedRate - 48_000) < 100 })
+    }
+
+    /// A trace of one cycle says nothing about cadence, and must not pretend to.
+    @Test func aSingleCycleYieldsNoReading() {
+        let readings = RateWindow.readings(
+            cycles(count: 1, actualRate: 48_000, configuredRate: 48_000),
+            ticksPerSecond: Self.ticks)
+
+        #expect(readings.isEmpty)
+    }
+
+    @Test func anEmptyTraceIsNotAnError() {
+        #expect(RateWindow.readings([], ticksPerSecond: Self.ticks).isEmpty)
+        #expect(RateWindow.widest([]) == nil)
+    }
+
+    // MARK: - The window
+
+    /// The case this exists for: a headset moving to its call profile while the
+    /// filters are still built for 48 kHz.
+    @Test func aCallProfileFlipIsMeasured() {
+        let before = cycles(count: 4, actualRate: 48_000, configuredRate: 48_000)
+        let stale = cycles(
+            count: 3, actualRate: 16_000, configuredRate: 48_000,
+            from: before.last!.hostTime &+ 10_667)
+        let after = cycles(
+            count: 4, actualRate: 16_000, configuredRate: 16_000,
+            from: stale.last!.hostTime &+ 32_000)
+
+        let widest = RateWindow.widest(
+            RateWindow.readings(before + stale + after, ticksPerSecond: Self.ticks))
+        let measurement = try! #require(widest)
+
+        #expect(measurement.configuredRate == 48_000)
+        #expect(abs(measurement.observedRate - 16_000) < 500)
+        #expect(measurement.seconds > 0)
+    }
+
+    /// What the user actually heard, which is the number worth reporting.
+    @Test func theWindowSaysWhereTheBandsWent() {
+        let measurement = RateWindow.Measurement(
+            seconds: 0.037, cycles: 3, configuredRate: 48_000, observedRate: 16_000)
+
+        #expect(abs(measurement.displacedKilohertzBand - 333) < 1)
+    }
+
+    /// Agreement is the normal case and must never be reported as a window.
+    @Test func aSteadyRateHasNoWindow() {
+        let readings = RateWindow.readings(
+            cycles(count: 20, actualRate: 44_100, configuredRate: 44_100),
+            ticksPerSecond: Self.ticks)
+
+        #expect(RateWindow.widest(readings) == nil)
+    }
+
+    /// 44.1 to 48 kHz is a 9% step. It is deliberately below the threshold: it
+    /// puts a 1 kHz band at 1088 Hz, which is not something anyone can hear, and
+    /// reporting it would bury the case that matters in ones that do not.
+    @Test func theCommonRateStepIsNotReportedAsAFault() {
+        let stale = cycles(count: 6, actualRate: 48_000, configuredRate: 44_100)
+        let readings = RateWindow.readings(stale, ticksPerSecond: Self.ticks)
+
+        #expect(RateWindow.widest(readings) == nil)
+    }
+
+    /// Scheduling jitter is not a rate change. An IO thread that wakes late once
+    /// must not be recorded as the device having changed underneath us.
+    @Test func aLateWakeUpIsNotAWindow() {
+        var trace = cycles(count: 8, actualRate: 48_000, configuredRate: 48_000)
+        // One cycle arrives 5% late, then the cadence resumes.
+        for index in 4..<trace.count {
+            trace[index].hostTime &+= 530
+        }
+
+        let readings = RateWindow.readings(trace, ticksPerSecond: Self.ticks)
+        #expect(RateWindow.widest(readings) == nil)
+    }
+
+    /// A trace can hold more than one route change. The worst is what decides
+    /// whether this is worth fixing, so that is what is reported.
+    @Test func theWidestWindowWins() {
+        let steady = cycles(count: 2, actualRate: 48_000, configuredRate: 48_000)
+        let brief = cycles(
+            count: 2, actualRate: 16_000, configuredRate: 48_000,
+            from: steady.last!.hostTime &+ 10_667)
+        let recovered = cycles(
+            count: 2, actualRate: 48_000, configuredRate: 48_000,
+            from: brief.last!.hostTime &+ 32_000)
+        let long = cycles(
+            count: 9, actualRate: 16_000, configuredRate: 48_000,
+            from: recovered.last!.hostTime &+ 10_667)
+
+        let readings = RateWindow.readings(
+            steady + brief + recovered + long, ticksPerSecond: Self.ticks)
+        let measurement = try! #require(RateWindow.widest(readings))
+
+        #expect(measurement.cycles >= 8, "the brief window was reported instead of the long one")
+    }
+
+    /// A trace that ends while the rate still disagrees still measures what it
+    /// saw, rather than discarding an unfinished window — the dump is taken on a
+    /// timer, so an unfinished window is a real outcome.
+    @Test func anUnfinishedWindowIsStillMeasured() {
+        let steady = cycles(count: 2, actualRate: 48_000, configuredRate: 48_000)
+        let stale = cycles(
+            count: 5, actualRate: 16_000, configuredRate: 48_000,
+            from: steady.last!.hostTime &+ 10_667)
+
+        let readings = RateWindow.readings(steady + stale, ticksPerSecond: Self.ticks)
+        #expect(RateWindow.widest(readings) != nil)
+    }
+
+    // MARK: - The report
+
+    @Test func theReportNamesTheWindowAndTheDisplacement() {
+        let before = cycles(count: 2, actualRate: 48_000, configuredRate: 48_000)
+        let stale = cycles(
+            count: 4, actualRate: 16_000, configuredRate: 48_000,
+            from: before.last!.hostTime &+ 10_667)
+        let events = [
+            RateEvent(hostTime: stale[1].hostTime, kind: .listenerFired, rate: 0),
+            RateEvent(hostTime: stale[3].hostTime, kind: .coefficientsRecomputed, rate: 16_000),
+        ]
+
+        let report = RateWindow.report(
+            cycles: before + stale, events: events, ticksPerSecond: Self.ticks)
+
+        #expect(report.contains("WINDOW"))
+        #expect(report.contains("1 kHz band sat at"))
+        #expect(report.contains("coefficients recomputed"))
+        #expect(report.contains("stale"))
+    }
+
+    @Test func aQuietReportSaysSoRatherThanNothing() {
+        let report = RateWindow.report(
+            cycles: cycles(count: 6, actualRate: 48_000, configuredRate: 48_000),
+            events: [], ticksPerSecond: Self.ticks)
+
+        #expect(report.contains("no disagreement"))
+    }
+
+    /// An event older than the oldest cycle still in the ring is ordinary: the
+    /// two rings are different lengths and are written by different threads.
+    /// Subtracting host times unsigned turned that into 768614336339369 ms,
+    /// which reads as a broken clock rather than as "before the trace begins".
+    @Test func anEventBeforeTheTraceReadsAsNegative() {
+        let trace = cycles(count: 4, actualRate: 48_000, configuredRate: 48_000, from: 100_000)
+        let earlier = [RateEvent(hostTime: 40_000, kind: .listenerFired, rate: 0)]
+
+        let report = RateWindow.report(
+            cycles: trace, events: earlier, ticksPerSecond: Self.ticks)
+
+        #expect(report.contains("-60.00 ms"), "an early event did not read as negative")
+        #expect(report.contains("768614") == false, "unsigned underflow is back")
+    }
+
+    /// The summary is what goes to the log, where a message is truncated long
+    /// before a few hundred cycles of table would fit.
+    @Test func theSummaryStandsAloneAndNamesTheWindow() {
+        let before = cycles(count: 2, actualRate: 44_100, configuredRate: 44_100)
+        let stale = cycles(
+            count: 5, actualRate: 16_000, configuredRate: 44_100,
+            from: before.last!.hostTime &+ 11_610)
+
+        let summary = RateWindow.summary(
+            RateWindow.readings(before + stale, ticksPerSecond: Self.ticks))
+
+        #expect(summary.contains("WINDOW"))
+        #expect(summary.contains("44100"))
+        #expect(summary.contains("16000"))
+        #expect(summary.count < 200, "a summary this long risks being truncated in the log")
+    }
+}

--- a/docs/DEVELOPMENT.org
+++ b/docs/DEVELOPMENT.org
@@ -512,6 +512,34 @@ Implemented in =AudioEngine.swift=:
    cycle, runs it through =EQProcessor=, and writes it to the real device's
    output buffers.
 
+*** Sample rate changes, and why there is no stale window
+
+Coefficients are a function of =2pi*f/fs=, so a device that changes rate while
+the filters are built for the old one puts every band in the wrong place — a
+Bluetooth headset moving to its call profile drops 44100 to 16000, which would
+put a 1 kHz bell at 363 Hz. CoreEQ learns of the change from a property
+listener, and a listener necessarily fires after the fact, so this looks like an
+unavoidable window.
+
+It is not, and the reason is worth knowing before anyone tries to close it:
+*Core Audio stops the device across a rate change*. Measured on a Jabra Evolve
+75, the new rate is staged within about two milliseconds of being reported and
+audio does not resume for another 120 to 330. The first buffer at the new rate
+lands on a render call that consumes the staged rate before filtering anything.
+
+=RateTrace= records the IO cadence — the frame count and host time of every
+cycle, four stores and no allocation — and =RateWindow= reads it afterwards, on
+the main thread, where the arithmetic is free. Frames divided by elapsed time
+*is* the device's real rate, which is the one thing nothing reports in time.
+Anything that disagrees with the configured rate by more than 10% is logged as a
+window, naming its width and where a 1 kHz band actually sat.
+
+The instrument ships rather than being deleted with the investigation. The
+guarantee above rests on a Core Audio behaviour rather than a documented
+promise, on one headset and one Mac; if it does not hold on someone else's
+hardware, this says so in a line of their log instead of being argued about from
+first principles.
+
 *** Proving the tap
 
 A tap is created *unmuted*, and the render path writes nothing, until the engine

--- a/docs/RELEASE_NOTES.org
+++ b/docs/RELEASE_NOTES.org
@@ -176,3 +176,60 @@ they had granted. Silence is not evidence. The engine now waits indefinitely,
 which costs nothing while the tap is unmuted, and concludes only when audio is
 demonstrably playing elsewhere and none of it is arriving. It also keeps
 watching afterwards, so a verdict corrects itself the moment a sample appears.
+
+** The route-change window that was not there
+
+Raised by a commenter who had built a system-audio capture tool and hit it:
+a Bluetooth headset moving to its call profile drops the output rate, and
+coefficients are a function of =2pi*f/fs=, so every band lands in the wrong
+place until they are recomputed. CoreEQ takes its rate from
+=kAudioDevicePropertyNominalSampleRate= rather than =kAudioTapPropertyFormat=,
+which avoids the version of the bug he described — but it still learns of the
+change from a property listener, and a listener fires after the fact. A window
+of audio filtered at the wrong rate looked unavoidable on paper.
+
+It does not happen, because *Core Audio stops the device across a rate change*.
+
+Measured on a Jabra Evolve 75, which offers exactly 44100 and 16000 Hz — the
+A2DP and HFP pair, a 2.76x shift that would have put a 1 kHz band at 363 Hz —
+and again on the built-in speakers, to check the result was not a property of
+Bluetooth:
+
+| device    | change            | reported -> staged | device silent | margin |
+|-----------+-------------------+--------------------+---------------+--------|
+| Jabra     | A2DP -> HFP       | 2.2 ms             | 174 ms        | 120 ms |
+| Jabra     | HFP -> A2DP       | 0.2 ms             | 385 ms        | 330 ms |
+| Built-in  | 96000 -> 44100 Hz | 4.1 ms             | 206 ms        | 206 ms |
+
+The new rate is staged within about two milliseconds of Core Audio reporting it,
+and audio does not resume for another 120 to 330. The first buffer at the new
+rate arrives at a render call that consumes the staged rate before it filters
+anything. Not one cycle ran on stale coefficients, in either direction, on a
+synthetic rate change or on a real profile switch driven by opening the
+microphone.
+
+*Not a defect.* Nothing was changed in the audio path, and the two mitigations
+that had been drafted were dropped as measurably pointless: the main-actor hop
+in the listener costs 0.2 ms against a margin of 120.
+
+What did ship is the instrument. =RateTrace= records the IO cadence — frame
+count and host time per cycle, four stores and no allocation on the audio
+path — and =RateWindow= reads it afterwards on the main thread, where frames
+divided by elapsed time gives the device's real rate, the one thing nothing
+reports in time. Any genuine window logs a line naming its width and where a
+1 kHz band actually sat.
+
+It ships rather than being deleted with the investigation because the result
+rests on a Core Audio behaviour rather than a documented promise, measured on
+two devices and one Mac. The diagnostics report now carries the answer — "rate
+window: none seen", or the width of the interval and where a 1 kHz band actually
+sat — so if this does not hold on someone else's hardware it arrives in their
+report rather than being argued from first principles. A line in a log would not
+have done: the people who hit this are running a downloaded app.
+
+Two bugs in the instrument itself were found by using it, which is the argument
+for having built it before trusting any conclusion: host times subtracted
+unsigned turned an event older than the trace into 768614336339369 ms, and
+=os_log= truncated the 500-row table away exactly where the interesting rows
+were. The summary now goes to the log and the table to a file, and only when
+there is a window to explain.

--- a/docs/ROADMAP.org
+++ b/docs/ROADMAP.org
@@ -26,7 +26,10 @@ Public feedback produced three defects that are not edge cases, and chasing the
 first turned up two more that nobody had reported. Three of the five are fixed
 and have moved to [[file:RELEASE_NOTES.org][RELEASE_NOTES.org]]: audio broken on multichannel outputs, an
 Aggregate or Multi-Output Device silencing the Mac outright, and a refused
-permission doing the same while every layer of the app reported success.
+permission doing the same while every layer of the app reported success. A
+fourth suspicion — that a Bluetooth route change left a window of audio filtered
+at the wrong sample rate — was measured and turned out not to happen; it is in
+the release notes with the numbers.
 
 What is left here: audio arriving twice and every screen capture tool failing, a
 Mac kept awake indefinitely, and two smaller reports. They affect people doing
@@ -43,17 +46,6 @@ documented as such — so it removes the systematic part of the headroom problem
 without guaranteeing clipping away. The mix level arriving at a tap is
 unknowable from inside it. If the noise is also present at Flat, it is not
 clipping and needs a real investigation.
-
-** The route-change window
-
-Coefficients come from =kAudioDevicePropertyNominalSampleRate=, not from
-=kAudioTapPropertyFormat=, which is what saves CoreEQ from the bug a commenter
-described where a Bluetooth headset flipping to HFP shifts every band down by
-2 to 3x. But the property listener fires *after* the route change, so there is
-still a window filtered with stale coefficients.
-
-Measure how wide it actually is before deciding whether it needs fixing. It may
-be a handful of buffers and inaudible.
 
 ** Echo and doubled audio
 
@@ -108,6 +100,35 @@ IO proc: =AudioDeviceStart= runs the aggregate continuously from launch, by
 design, since global bypass “keeps the engine running but passes audio through”
 (=AudioEngine.swift:49=). A continuously running IOProc is active audio IO as
 far as the system is concerned, so the assertion follows automatically.
+
+*That explanation is wrong, and the real one is narrower.* Measured while
+investigating the route-change window: with the engine running and nothing
+playing, =RateTrace= recorded *no IO cycles at all* over twenty-two seconds, on
+the Jabra and again on the built-in speakers. The render callback is not being
+called. So it is not a continuously running IOProc.
+
+=pmset -g assertions=, taken at the same moment, names what it actually is:
+
+#+begin_example
+pid 401(coreaudiod): PreventUserIdleSystemSleep named:
+  "com.apple.audio.com.andreypudov.coreeq.aggregate.<uid>.context.preventuseridlesleep"
+  Created for PID: 36385.
+  Resources: audio-in audio-out BuiltInSpeakerDevice
+#+end_example
+
+The assertion belongs to *coreaudiod*, raised for CoreEQ's aggregate device and
+attributed back to CoreEQ's pid — which is why Activity Monitor blames an app
+whose own source contains no assertion, and why searching that source for one
+found nothing. It is held because the aggregate has been *started*, not because
+audio is flowing: it was there with zero callbacks in twenty-two seconds.
+
+That changes the fix. Making the IO path idle-aware achieves nothing, because it
+is already idle. The assertion goes away only by stopping the aggregate
+(=AudioDeviceStop=) when nothing is playing and starting it again on demand,
+which is a real design change: something has to notice playback beginning, the
+restart has to be fast enough not to clip the first moment of it, and the tap's
+mute behaviour has to survive the cycle. Worth doing, and worth its own design
+rather than an afternoon.
 
 The fix is to stop running when there is nothing to do: tear the IO proc down
 when the app is bypassed, and when the mix has been silent for long enough that

--- a/docs/ROADMAP.org
+++ b/docs/ROADMAP.org
@@ -47,6 +47,14 @@ without guaranteeing clipping away. The mix level arriving at a tap is
 unknowable from inside it. If the noise is also present at Flat, it is not
 clipping and needs a real investigation.
 
+*The report now answers this without a round trip.* The render path keeps the
+largest magnitude it has produced since the engine started and counts the
+samples that did not fit, and the diagnostics report carries both — =peak
+output: 0.71, no clipping=, or the peak with a count and what to do about it.
+Until now the only way to tell was to ask the reporter to switch to Flat and
+come back, which is two exchanges to answer a question their own machine
+already knew. Next time this is reported, ask for the report first.
+
 ** Echo and doubled audio
 
 Three symptoms that sound like one another, and the second is the one that makes
@@ -82,7 +90,10 @@ that is what a capture tool and CoreEQ are doing to each other.
 Three things to do:
 
 - Audit the teardown and rebuild path around sleep, wake, and device changes,
-  and confirm exactly one IO proc is ever running.
+  and confirm exactly one IO proc is ever running. The report now names how many
+  restarts a session has had, why the last one happened, and how long ago, so a
+  report filed alongside an echo says whether a state change preceded it — the
+  wake-from-sleep case is a restart by definition.
 - Reproduce against a screen capture tool. Capture tools take their own tap of
   the system audio, so CoreEQ's global tap and theirs are interacting.
   “Every capture tool fails” makes this a real conflict, not a quirk of one app.


### PR DESCRIPTION
**The route-change window doesn't exist.** A Bluetooth headset switching to its
call profile drops 44100 → 16000 Hz, which would put a 1 kHz band at 363 Hz
until the coefficients catch up. Measured on a Jabra Evolve 75 and again on the
built-in speakers: Core Audio *stops the device* across a rate change, the new
rate is staged 0.2–4 ms after being reported, and audio doesn't resume for
another 120–330 ms. No cycle ever ran on stale coefficients, in either
direction, so both drafted mitigations were dropped as measurably pointless.

`RateTrace` and `RateWindow` ship anyway — four stores per IO cycle, no
allocation on the audio path. The result rests on a Core Audio behaviour rather
than a documented promise, measured on one Mac, so if it doesn't hold elsewhere
it now arrives in the user's report instead of being argued from first
principles.

**The diagnostics report gained four fields**, each chosen because it settles an
open roadmap item:

- `peak output` and clipped-sample count — the open Bluetooth-noise reports
  currently take two exchanges to rule out clipping
- `restarts`, with reason and age — the echo-after-wake reports are about
  something that follows a restart
- uptime on the status line — `no audio seen` means nothing without it
- `rate window` — none seen, or its width and where a 1 kHz band actually sat

Also found while measuring, and recorded in the roadmap rather than acted on:
the sleep item's stated cause is wrong. `pmset` shows the assertion held by
coreaudiod for CoreEQ's aggregate and attributed to its pid, with zero IO
callbacks in 22 seconds — so it's the *started aggregate*, not a running IOProc.
That changes the fix, and it deserves its own design.

425 tests.