### PR TITLE
~ let the mac sleep when nothing is playing

### DIFF
--- a/CoreEQ/App/AppDelegate.swift
+++ b/CoreEQ/App/AppDelegate.swift
@@ -173,6 +173,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             window.toolbarStyle = .unified
 
             window.isReleasedWhenClosed = false
+            // Tab has to reach controls that did not exist when the window was
+            // built. This defaults to false for a window created in code rather
+            // than loaded from a nib, and with it false AppKit works out the
+            // key-view loop once and never revisits it — so a parametric band
+            // added afterwards had fields that Tab did not know about, and
+            // tabbing off the last row it *did* know about wrapped to the top.
+            //
+            // It looked like a bug about the last row, which is what made it
+            // hard to see: the give-away was that four bands behaved differently
+            // depending on how you arrived at four, because removing a band
+            // invalidates the loop and forces the rebuild that adding one does
+            // not.
+            window.autorecalculatesKeyViewLoop = true
             window.contentMinSize = MainWindowGeometry.minimum
             window.setContentSize(
                 MainWindowGeometry.openingSize(visibleFrame: NSScreen.main?.visibleFrame.size))

--- a/CoreEQ/App/EngineStatusBridge.swift
+++ b/CoreEQ/App/EngineStatusBridge.swift
@@ -47,6 +47,7 @@ final class EngineStatusBridge: ObservableObject {
     var uptime: TimeInterval? { engine?.uptime }
     var restarts: DiagnosticsReport.Restarts { engine?.restarts ?? DiagnosticsReport.Restarts() }
     var level: DiagnosticsReport.Level { engine?.level ?? DiagnosticsReport.Level() }
+    var idling: DiagnosticsReport.Idling { engine?.idling ?? DiagnosticsReport.Idling() }
 
     func follow(_ engine: AudioEngine) {
         self.engine = engine

--- a/CoreEQ/App/SettingsStore.swift
+++ b/CoreEQ/App/SettingsStore.swift
@@ -20,6 +20,7 @@ final class SettingsStore {
         static let userProfiles = "userProfiles"
         static let deviceStates = "deviceStates"
         static let lastOutputDeviceUID = "lastOutputDeviceUID"
+        static let pausesWhenSilent = "pausesWhenSilent"
     }
 
     private let defaults: UserDefaults
@@ -47,6 +48,19 @@ final class SettingsStore {
     var isEnabled: Bool {
         get { defaults.object(forKey: Key.isEnabled) as? Bool ?? true }
         set { defaults.set(newValue, forKey: Key.isEnabled) }
+    }
+
+    /// Whether CoreEQ releases the audio device while nothing is playing.
+    ///
+    /// On by default, because holding it is what keeps a Mac awake all night.
+    /// Off exists because this app has three times shipped a change that
+    /// silenced someone's machine, and every one of those had no workaround
+    /// from inside the app — quitting was the only fix, which is not
+    /// discoverable for something that launches at login. A switch costs one
+    /// line of settings and turns the next such bug into an inconvenience.
+    var pausesWhenSilent: Bool {
+        get { defaults.object(forKey: Key.pausesWhenSilent) as? Bool ?? true }
+        set { defaults.set(newValue, forKey: Key.pausesWhenSilent) }
     }
 
     /// Band gains dialed in on top of the active profile by CoreEQ 1.x.

--- a/CoreEQ/Audio/AudioDevices.swift
+++ b/CoreEQ/Audio/AudioDevices.swift
@@ -315,6 +315,21 @@ enum AudioDevices {
         outputBufferChannels(of: deviceID).reduce(0, +)
     }
 
+    /// Whether anything at all is using this device right now.
+    ///
+    /// One property on one object, at about 0.05 ms — a hundred times cheaper
+    /// than asking every audio process the same question, and unlike
+    /// `kAudioProcessPropertyIsRunningOutput` it actually sends notifications.
+    /// Only meaningful about *other* users of the device when CoreEQ's own IO
+    /// proc is stopped, which is exactly when it is asked.
+    static func isRunningSomewhere(_ deviceID: AudioDeviceID) -> Bool {
+        var runningAddress = address(kAudioDevicePropertyDeviceIsRunningSomewhere)
+        var isRunning: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        return AudioObjectGetPropertyData(deviceID, &runningAddress, 0, nil, &size, &isRunning)
+            == noErr && isRunning != 0
+    }
+
     /// Whether any process other than `excluding` is currently playing audio.
     ///
     /// This is what stops a quiet Mac being mistaken for a refused permission.

--- a/CoreEQ/Audio/AudioEngine.swift
+++ b/CoreEQ/Audio/AudioEngine.swift
@@ -128,6 +128,15 @@ final class AudioEngine: ObservableObject {
             peak: processor.peakLevel, clippedSamples: processor.clippedSamples)
     }
 
+    /// Whether the audio device has been let go, and the history of that.
+    var idling: DiagnosticsReport.Idling {
+        DiagnosticsReport.Idling(
+            isIdle: isIdle,
+            isEnabled: settings.pausesWhenSilent,
+            releases: idleCount,
+            totalSeconds: totalIdle + (idleSince.map { -$0.timeIntervalSinceNow } ?? 0))
+    }
+
     var rateWindow: RateWindow.Measurement? {
         let trace = processor.rateTrace.snapshot()
         return RateWindow.widest(
@@ -158,6 +167,11 @@ final class AudioEngine: ObservableObject {
             guard isEnabled != oldValue else { return }
             processor.setBypassed(!isEnabled)
             settings.isEnabled = isEnabled
+            // Acted on at once rather than at the next poll, in both
+            // directions: switching off should let go of the machine
+            // immediately, and switching back on should not wait half a second
+            // to start working.
+            evaluateIdleState()
         }
     }
 
@@ -192,8 +206,56 @@ final class AudioEngine: ObservableObject {
     private var streamConfigListener: AudioObjectPropertyListenerBlock?
     private var wakeObserver: (any NSObjectProtocol)?
     private var activationObserver: (any NSObjectProtocol)?
+    /// A rebuild that has been scheduled but has not run yet.
+    ///
+    /// Nil means none is pending, and that has to stay true: it is read as a
+    /// "mid-transition" flag, not just as something to cancel. It was cancelled
+    /// but never cleared once, and the stale reference made the engine believe a
+    /// restart was permanently in flight — which silently disabled idling for
+    /// every session, because the device-change listener fires once at launch.
+    /// Cleared in all three places it can end: cancelled by `start`, cancelled
+    /// by `stop`, and completed by its own work item.
     private var pendingRestart: DispatchWorkItem?
     private var capturePoll: DispatchWorkItem?
+    private var idlePoll: DispatchWorkItem?
+
+    /// What tells the engine that audio is starting, so a resume is not waiting
+    /// on a timer.
+    ///
+    /// Push, not poll, because the delay before CoreEQ starts processing again
+    /// is heard: at a half-second poll roughly a second of audio played
+    /// unequalized, which was reported as very noticeable. The device itself
+    /// needs about 90 ms to deliver its first buffer after `AudioDeviceStart`,
+    /// so anything above that is the app's own dithering.
+    ///
+    /// Two listeners, because measurement ruled out the obvious one.
+    /// `kAudioProcessPropertyIsRunningOutput` sends no notifications at all —
+    /// attached to every process, it never fired once — and sweeping every
+    /// process by hand costs 6 ms a pass, far too much to do often.
+    /// `kAudioDevicePropertyDeviceIsRunningSomewhere` does notify, costs 0.05 ms
+    /// to read, and is false while CoreEQ is idle, so it says exactly what is
+    /// wanted: somebody else wants this device.
+    private var deviceRunningListener: AudioObjectPropertyListenerBlock?
+    /// A process appearing in the audio process list, which measured about 80 ms
+    /// *before* it starts playing — enough of a head start to cover the device's
+    /// own warm-up.
+    private var processListListener: AudioObjectPropertyListenerBlock?
+    /// Set by that listener and cleared once acted on.
+    private var audioStarting = false
+    /// The device the aggregate is built around, which is what the running
+    /// listener watches — not the aggregate, whose own state is CoreEQ's.
+    private var outputDeviceID = AudioObjectID(kAudioObjectUnknown)
+
+    /// Whether the audio path has been released because nothing was playing.
+    ///
+    /// Deliberately *not* part of `Status`. From the user's side nothing has
+    /// changed — CoreEQ is on, and the next sound will be equalized — so the
+    /// menu bar icon must go on saying so. An idle engine that reported itself
+    /// stopped would blink the icon off every time a room went quiet.
+    private(set) var isIdle = false
+    private var idleCount = 0
+    private var idleSince: Date?
+    private var totalIdle: TimeInterval = 0
     /// Whether a tap has been seen delivering audio in this session.
     ///
     /// Not persisted. A permission can be withdrawn between launches, and the
@@ -223,6 +285,7 @@ final class AudioEngine: ObservableObject {
 
     func start() {
         pendingRestart?.cancel()
+        pendingRestart = nil
         // The verdict belongs to the attempt that produced it. Carrying it into
         // the next one would leave the app reporting a refusal it is in the
         // middle of retrying.
@@ -236,11 +299,14 @@ final class AudioEngine: ObservableObject {
         // failure was permanent in the strong sense, until the app was
         // relaunched. Installed here, a device change always gets a hearing.
         installDefaultDeviceListenerIfNeeded()
+        installPlaybackListenersIfNeeded()
         installWakeObserverIfNeeded()
         installActivationObserverIfNeeded()
         do {
             try startEngine()
             retryCount = 0
+            isIdle = false
+            scheduleIdleCheck()
         } catch {
             teardownEngine()
             let message =
@@ -266,10 +332,14 @@ final class AudioEngine: ObservableObject {
     /// termination.
     func stop() {
         pendingRestart?.cancel()
+        pendingRestart = nil
+        idlePoll?.cancel()
+        idlePoll = nil
         removeSystemObservers()
         teardownEngine()
         diagnostics = nil
         startedAt = nil
+        isIdle = false
         status = .stopped
     }
 
@@ -313,6 +383,7 @@ final class AudioEngine: ObservableObject {
         processor.setOutputLayout(layout)
 
         try startIOProc(on: aggregateID)
+        installDeviceRunningListener(on: device.id)
 
         // Only the two tied to this aggregate. The device and wake observers are
         // installed by `start()`, so that they exist even when this throws.
@@ -519,6 +590,15 @@ final class AudioEngine: ObservableObject {
     /// How often to look for the first sample.
     private static let capturePollInterval: TimeInterval = 0.25
 
+    /// How often the idle decision is revisited when nothing has told us to.
+    ///
+    /// A backstop, not the mechanism: `playbackListeners` is what makes resuming
+    /// prompt, and this only catches anything they miss. Slow on purpose — going
+    /// idle a couple of seconds late costs nothing against a thirty second
+    /// threshold, and a timer that fires rarely is a timer that costs no
+    /// battery.
+    private static let idlePollInterval: TimeInterval = 2.0
+
     /// How long the tap may deliver nothing *while something else is playing*
     /// before the engine says it is not capturing.
     ///
@@ -579,6 +659,145 @@ final class AudioEngine: ObservableObject {
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.capturePollInterval, execute: work)
     }
 
+    // MARK: - Idling
+
+    /// Revisits the idle decision on a timer, forever.
+    ///
+    /// One timer covers both directions. While running it is asking whether the
+    /// device can be let go; while idle it is asking whether anything wants to
+    /// play. Two timers would be two things to keep in step, and the state they
+    /// disagreed about would be whether the Mac has any audio at all.
+    private func scheduleIdleCheck() {
+        idlePoll?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.evaluateIdleState()
+            self.scheduleIdleCheck()
+        }
+        idlePoll = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.idlePollInterval, execute: work)
+    }
+
+    /// Acts on `IdlePolicy`, and does nothing else.
+    ///
+    /// Every condition lives in the policy so that it can be tested without an
+    /// audio device; this is only the hands. Anything resembling a decision that
+    /// appears here belongs there instead.
+    private func evaluateIdleState() {
+        // Never while the tap is still being proved, and never while a restart
+        // is already in flight: both are mid-transition, and a teardown from
+        // underneath either leaves state describing a path that no longer
+        // exists.
+        guard !isMidTransition else { return }
+
+        // Two different questions, because "is anyone playing" has two different
+        // right answers depending on whether CoreEQ is one of them. Idle, the
+        // device is not ours and its own running flag is both cheaper and
+        // faster. Running, it would always be true — we are the one using it —
+        // so the processes have to be asked instead, excluding ourselves.
+        //
+        // And running, the question is only asked when it can change the answer.
+        // Sweeping every audio process costs about 6 ms; below the silence
+        // threshold the verdict is `keepRunning` whatever it returns, so paying
+        // that every couple of seconds for the whole life of the app would be
+        // battery spent to confirm something already known.
+        let isAnythingPlaying: Bool
+        if isIdle {
+            isAnythingPlaying = AudioDevices.isRunningSomewhere(outputDeviceID)
+        } else if processor.silentSeconds >= IdlePolicy.idleAfter {
+            isAnythingPlaying = AudioDevices.isAnyProcessPlayingOutput(
+                excluding: tapExcludedProcess)
+        } else {
+            isAnythingPlaying = false
+        }
+
+        let verdict = IdlePolicy.evaluate(
+            isRunning: !isIdle && ioProcID != nil,
+            silentSeconds: processor.silentSeconds,
+            isAnythingPlaying: isAnythingPlaying,
+            isEnabled: isEnabled,
+            isCaptureProven: captureProven,
+            pausesWhenSilent: settings.pausesWhenSilent,
+            isAudioStarting: audioStarting,
+            isRecovering: status.summary != nil)
+        audioStarting = false
+
+        switch verdict {
+        case .keepRunning, .stayIdle:
+            return
+        case .goIdle:
+            goIdle()
+        case .resume:
+            resumeFromIdle()
+        }
+    }
+
+    /// Whether the engine is between states, and must not be touched.
+    ///
+    /// A rebuild already scheduled, or a tap still being proved. Tearing down
+    /// from under either leaves state describing a path that no longer exists —
+    /// and in the proving case it would destroy the very path that has to run
+    /// for the permission answer to arrive.
+    private var isMidTransition: Bool {
+        pendingRestart != nil || (capturePoll != nil && !captureProven)
+    }
+
+    /// Releases the sleep assertion by stopping the IO proc, and nothing else.
+    ///
+    /// The tap and the aggregate stay alive on purpose. The first version of
+    /// this tore the whole path down and rebuilt it on resume, which broke
+    /// playback outright over Bluetooth: rebuilding means creating a new
+    /// aggregate around the output device at the exact moment a player is
+    /// opening that device, so the device is reconfigured — and on Bluetooth
+    /// renegotiated — underneath the client that just grabbed it. Players failed
+    /// to start and only succeeded after several attempts, because each attempt
+    /// was a race against us.
+    ///
+    /// Stopping is enough. `AudioDeviceStop` alone releases the assertion, and
+    /// a tap left alive does *not* silence other processes while nothing is
+    /// consuming it — both measured, the second because assuming it would was
+    /// what made the destructive version look necessary. So while idle, audio
+    /// plays normally and unprocessed, and resuming touches no topology at all.
+    private func goIdle() {
+        guard !isIdle, let ioProcID, aggregateID != kAudioObjectUnknown else { return }
+        AudioDeviceStop(aggregateID, ioProcID)
+        isIdle = true
+        idleCount += 1
+        idleSince = Date()
+        // `status` is deliberately untouched. Nothing has changed for the user:
+        // CoreEQ is on, and the next sound will be equalized.
+        logger.info("Idle: stopped the IO proc, nothing is playing")
+    }
+
+    /// Starts the IO proc again because something wants to play.
+    ///
+    /// One call, against a device that was never taken apart. Nothing is
+    /// created, nothing is renegotiated, and the player that triggered this
+    /// keeps the device it just opened.
+    private func resumeFromIdle() {
+        guard isIdle else { return }
+        guard let ioProcID, aggregateID != kAudioObjectUnknown else {
+            // The path went away underneath us — a device change, or a failed
+            // start. Rebuilding is the only option left, and it is safe here
+            // because there is nothing to disturb.
+            isIdle = false
+            start()
+            return
+        }
+        if let idleSince { totalIdle += -idleSince.timeIntervalSinceNow }
+        idleSince = nil
+        isIdle = false
+        // The delay lines describe audio from before the pause.
+        processor.prepareForResume()
+        let status = AudioDeviceStart(aggregateID, ioProcID)
+        if status != noErr {
+            logger.error("Resume failed (\(status)); rebuilding")
+            start()
+            return
+        }
+        logger.info("Resuming: audio is playing")
+    }
+
     /// Our own audio process object, so our playback is not counted as evidence
     /// that audio is reaching everything *except* us.
     private var tapExcludedProcess: AudioObjectID {
@@ -589,7 +808,73 @@ final class AudioEngine: ObservableObject {
 
     /// Removes the observers that survive a restart. `start()` reinstalls both,
     /// so stopping and starting again is a complete cycle.
+    /// Watches for anything starting to play, so a resume does not wait for a
+    /// timer.
+    ///
+    /// Two kinds are needed and one alone is not enough: a listener per process
+    /// catches an app that is already known to Core Audio, and a listener on the
+    /// process list catches one that has just appeared — measured, a freshly
+    /// launched player fires no per-process notification, because there was no
+    /// process object to attach to when the listeners went on.
+    private func installPlaybackListenersIfNeeded() {
+        guard processListListener == nil else { return }
+        var addr = propertyAddress(kAudioHardwarePropertyProcessObjectList)
+        let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.audioStarting = true
+                self.evaluateIdleState()
+            }
+        }
+        let status = AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject), &addr, .main, block)
+        if status == noErr {
+            processListListener = block
+        } else {
+            logger.error("Failed to observe the audio process list: \(status)")
+        }
+    }
+
+    /// Watches the output device for anyone else starting to use it.
+    ///
+    /// On the device rather than the aggregate: the aggregate's running state is
+    /// CoreEQ's own, and would say nothing about who else wants to play.
+    private func installDeviceRunningListener(on deviceID: AudioObjectID) {
+        removeDeviceRunningListener()
+        var addr = propertyAddress(kAudioDevicePropertyDeviceIsRunningSomewhere)
+        let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            MainActor.assumeIsolated { self?.evaluateIdleState() }
+        }
+        if AudioObjectAddPropertyListenerBlock(deviceID, &addr, .main, block) == noErr {
+            deviceRunningListener = block
+            outputDeviceID = deviceID
+        } else {
+            logger.error("Failed to observe whether \(deviceID) is in use")
+        }
+    }
+
+    private func removeDeviceRunningListener() {
+        if let deviceRunningListener, outputDeviceID != kAudioObjectUnknown {
+            var addr = propertyAddress(kAudioDevicePropertyDeviceIsRunningSomewhere)
+            AudioObjectRemovePropertyListenerBlock(
+                outputDeviceID, &addr, .main, deviceRunningListener)
+        }
+        deviceRunningListener = nil
+        outputDeviceID = AudioObjectID(kAudioObjectUnknown)
+    }
+
+    private func removePlaybackListeners() {
+        if let processListListener {
+            var addr = propertyAddress(kAudioHardwarePropertyProcessObjectList)
+            AudioObjectRemovePropertyListenerBlock(
+                AudioObjectID(kAudioObjectSystemObject), &addr, .main, processListListener)
+        }
+        processListListener = nil
+        removeDeviceRunningListener()
+    }
+
     private func removeSystemObservers() {
+        removePlaybackListeners()
         if let defaultDeviceListener {
             var addr = propertyAddress(kAudioHardwarePropertyDefaultOutputDevice)
             AudioObjectRemovePropertyListenerBlock(
@@ -616,7 +901,10 @@ final class AudioEngine: ObservableObject {
         lastRestartReason = reason
         lastRestartAt = Date()
         pendingRestart?.cancel()
-        let work = DispatchWorkItem { [weak self] in self?.start() }
+        let work = DispatchWorkItem { [weak self] in
+            self?.pendingRestart = nil
+            self?.start()
+        }
         pendingRestart = work
         DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
     }

--- a/CoreEQ/Audio/AudioEngine.swift
+++ b/CoreEQ/Audio/AudioEngine.swift
@@ -102,7 +102,7 @@ final class AudioEngine: ObservableObject {
     /// thread, and the only thing that wants it is a diagnostics report being
     /// drawn — publishing it would mean waking the UI for a fact nobody is
     /// looking at.
-    var hasReceivedAudio: Bool { processor.hasReceivedAudio }
+    var hasReceivedAudio: Bool { processor.observed.hasReceivedAudio }
 
     /// The widest interval the render path has spent filtering at a rate the
     /// device was not using. Nil when there has been none, which is every
@@ -125,7 +125,7 @@ final class AudioEngine: ObservableObject {
     /// fit.
     var level: DiagnosticsReport.Level {
         DiagnosticsReport.Level(
-            peak: processor.peakLevel, clippedSamples: processor.clippedSamples)
+            peak: processor.observed.peakLevel, clippedSamples: processor.observed.clippedSamples)
     }
 
     /// Whether the audio device has been let go, and the history of that.
@@ -623,7 +623,7 @@ final class AudioEngine: ObservableObject {
             guard let self, self.ioProcID != nil, !self.captureProven else { return }
 
             let (verdict, silent) = CaptureProof.evaluate(
-                hasReceivedAudio: self.processor.hasReceivedAudio,
+                hasReceivedAudio: self.processor.observed.hasReceivedAudio,
                 isAnythingPlaying: AudioDevices.isAnyProcessPlayingOutput(
                     excluding: self.tapExcludedProcess),
                 silentWhilePlaying: silentWhilePlaying,
@@ -704,7 +704,7 @@ final class AudioEngine: ObservableObject {
         let isAnythingPlaying: Bool
         if isIdle {
             isAnythingPlaying = AudioDevices.isRunningSomewhere(outputDeviceID)
-        } else if processor.silentSeconds >= IdlePolicy.idleAfter {
+        } else if processor.observed.silentSeconds >= IdlePolicy.idleAfter {
             isAnythingPlaying = AudioDevices.isAnyProcessPlayingOutput(
                 excluding: tapExcludedProcess)
         } else {
@@ -713,7 +713,7 @@ final class AudioEngine: ObservableObject {
 
         let verdict = IdlePolicy.evaluate(
             isRunning: !isIdle && ioProcID != nil,
-            silentSeconds: processor.silentSeconds,
+            silentSeconds: processor.observed.silentSeconds,
             isAnythingPlaying: isAnythingPlaying,
             isEnabled: isEnabled,
             isCaptureProven: captureProven,

--- a/CoreEQ/Audio/Capture/DiagnosticsReport.swift
+++ b/CoreEQ/Audio/Capture/DiagnosticsReport.swift
@@ -60,6 +60,22 @@ enum DiagnosticsReport {
         var isClipping: Bool { clippedSamples > 0 }
     }
 
+    /// Whether CoreEQ has stopped its IO proc, and how often.
+    ///
+    /// An idle engine is invisible from outside: the EQ is on, nothing is
+    /// playing, and the next sound will be equalized. That is also exactly what
+    /// a *failure* to come back looks like until someone plays something, so the
+    /// report has to say which state the engine is in and how much time it has
+    /// spent there. Without it, "the EQ stopped working" and "the EQ is waiting"
+    /// are the same report.
+    struct Idling: Equatable {
+        var isIdle = false
+        /// Whether the behaviour is switched on at all.
+        var isEnabled = true
+        var releases = 0
+        var totalSeconds: TimeInterval = 0
+    }
+
     /// What the running engine actually settled on, as opposed to what a device
     /// says it can do. This is the half a command line tool cannot report: it
     /// would have to build its own tap and infer.
@@ -111,6 +127,7 @@ enum DiagnosticsReport {
         var uptime: TimeInterval?
         var restarts = Restarts()
         var level = Level()
+        var idling = Idling()
     }
 
     /// How the saved EQ is keyed, which is the fact that settles "my preset did
@@ -189,6 +206,17 @@ enum DiagnosticsReport {
                 "  muting others:   "
                     + (engine.isMuting
                         ? "yes" : "no — not proven able to capture, so audio is left alone"))
+            if !engine.idling.isEnabled {
+                lines.append("  idling:          off (releasing the device is disabled)")
+            } else if engine.idling.isIdle {
+                lines.append(
+                    "  idling:          YES — IO stopped, waiting for something to play")
+            } else {
+                lines.append(
+                    "  idling:          no, "
+                        + "\(engine.idling.releases) release(s) this session, "
+                        + "\(describe(duration: engine.idling.totalSeconds)) total")
+            }
             if engine.restarts.count > 0 {
                 let reason = engine.restarts.lastReason ?? "unknown"
                 let ago = engine.restarts.since.map { ", \(describe(duration: $0)) ago" } ?? ""

--- a/CoreEQ/Audio/Capture/IdlePolicy.swift
+++ b/CoreEQ/Audio/Capture/IdlePolicy.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+/// Whether the audio path should be running at all.
+///
+/// A started aggregate device makes coreaudiod hold a
+/// `PreventUserIdleSystemSleep` assertion on CoreEQ's behalf. That is correct
+/// while audio is playing and wrong afterwards: measured, Core Audio spins the
+/// IO context up on the first sound and never spins it back down, so a Mac that
+/// played something once at breakfast is still being held awake at midnight.
+/// The assertion is released by `AudioDeviceStop` alone.
+///
+/// So the rule is: stop when there is demonstrably nothing to do, and come back
+/// the moment there is. This decides both, and does so as a pure function
+/// because the cost of getting it wrong is the failure this app has shipped
+/// three times — a Mac producing no sound while every layer reports success.
+/// A rule that can be tested against a hundred invented sequences is worth more
+/// than one that can only be tested by playing music and waiting.
+enum IdlePolicy {
+
+    /// What the engine should do next.
+    enum Verdict: Equatable {
+        case keepRunning
+        /// Tear the audio path down, releasing the device and the assertion.
+        case goIdle
+        case stayIdle
+        /// Build it again, because something wants to play.
+        case resume
+    }
+
+    /// Silence that means nothing is playing, rather than a gap between tracks.
+    ///
+    /// Thirty seconds is long enough that no pause inside listening reaches it —
+    /// a gap between albums, a paused video someone comes back to — and short
+    /// enough that a machine left alone still sleeps on schedule. It is also
+    /// well past the point where a rebuild's 27 ms could be noticed.
+    static let idleAfter: TimeInterval = 30
+
+    /// - Parameters:
+    ///   - isRunning: whether the audio path exists right now.
+    ///   - silentSeconds: how long the render path has seen nothing but digital
+    ///     zero. Meaningless while not running, and ignored there.
+    ///   - isAnythingPlaying: whether any other process is playing output. The
+    ///     only signal available while idle, since the render path is gone.
+    ///   - isEnabled: whether the user has CoreEQ switched on at all.
+    ///   - isCaptureProven: whether a tap has been seen delivering audio.
+    ///   - pausesWhenSilent: the user's setting. False pins the engine on.
+    ///   - isAudioStarting: whether something has just announced itself as about
+    ///     to use audio, which arrives slightly before it plays.
+    ///   - isRecovering: whether the last attempt to build the path failed.
+    ///   - idleAfter: the silence that counts as nothing playing.
+    /// - Returns: what to do.
+    static func evaluate(
+        isRunning: Bool,
+        silentSeconds: TimeInterval,
+        isAnythingPlaying: Bool,
+        isEnabled: Bool,
+        isCaptureProven: Bool,
+        pausesWhenSilent: Bool,
+        isAudioStarting: Bool = false,
+        isRecovering: Bool = false,
+        idleAfter: TimeInterval = idleAfter
+    ) -> Verdict {
+        // A path that cannot be built is not a path that should be built twice a
+        // second. When the last attempt failed, recovery belongs to the retry
+        // that already owns it — with its own backoff and its own limit — and
+        // this must keep its hands off. Without this, an output device the
+        // engine refuses would be retried at the poll interval forever, which is
+        // the same fault as a retry loop with no ceiling.
+        guard !isRecovering else { return isRunning ? .keepRunning : .stayIdle }
+
+        // The escape hatch, and the first thing checked. Every silent-Mac defect
+        // in this app's history had no workaround from inside the app; this one
+        // has a switch, and the switch has to win over every rule below it.
+        guard pausesWhenSilent else { return isRunning ? .keepRunning : .resume }
+
+        guard isRunning else {
+            // Switched off, there is nothing to come back for: the audio path
+            // would be built only to pass audio through untouched.
+            guard isEnabled else { return .stayIdle }
+            // `isAudioStarting` is deliberately enough on its own. The device
+            // needs about 90 ms to deliver its first buffer after being
+            // started, and a process announcing itself arrives about 80 ms
+            // before it plays — so acting on the announcement is what turns a
+            // gap of unequalized audio into no gap at all. Being wrong costs
+            // one idle period, which is thirty seconds of a device nobody is
+            // using; being late costs audio the user hears.
+            return (isAnythingPlaying || isAudioStarting) ? .resume : .stayIdle
+        }
+
+        // Switched off is the clearest case there is — no audio is being
+        // processed, so nothing is lost by releasing the device at once.
+        guard isEnabled else { return .goIdle }
+
+        // Silence is only evidence when the tap is known to deliver. Before that
+        // it is equally the sound of a permission that was refused, and idling
+        // on it would tear down the very path that has to run to find out.
+        guard isCaptureProven else { return .keepRunning }
+
+        // Both signals have to agree, and that is not belt and braces — it is
+        // what stops the engine oscillating. Silence is measured by the render
+        // path and playback by the system, and they can disagree: a process is
+        // free to hold the device open while sending nothing but zeros. Idling
+        // on silence alone would then meet a resume on playback alone, and the
+        // audio path would be rebuilt every thirty seconds for as long as that
+        // process ran. Requiring both makes `goIdle` and `resume` impossible to
+        // reach from the same state.
+        //
+        // The cost is that an app which never lets go of the device keeps the
+        // Mac awake. That is exactly today's behaviour, so the conservative
+        // failure is no worse than no fix at all — which is the right direction
+        // to fail in.
+        guard !isAnythingPlaying else { return .keepRunning }
+
+        return silentSeconds >= idleAfter ? .goIdle : .keepRunning
+    }
+}

--- a/CoreEQ/EQ/BufferRouter.swift
+++ b/CoreEQ/EQ/BufferRouter.swift
@@ -1,0 +1,210 @@
+import CoreAudio
+import Foundation
+
+/// Moves the tap's channels into the device's output channels.
+///
+/// The other half of `OutputPlan`, which works out on the main thread *where*
+/// each tap channel should go; this carries that out on the render thread. They
+/// are separate because one may read device properties and take its time, and
+/// the other may do neither.
+///
+/// Nothing here reasons about audio. It reasons about buffer lists: which
+/// buffer holds a channel, where in it that channel starts, and how far apart
+/// its samples are. That is the whole job, and it is worth its own type because
+/// getting it wrong is silent — a channel written to the wrong place, or four
+/// frames of stereo smeared across one frame of eight, sounds like a broken
+/// device rather than like a bug.
+///
+/// A struct, stored inline by the processor: this is touched once per channel
+/// per block on the audio thread, where a class would add a retain and an
+/// indirection for nothing.
+struct BufferRouter {
+
+    /// Where one channel lives in a buffer list.
+    struct Span {
+        var pointer: UnsafeMutablePointer<Float>
+        /// Distance between consecutive samples of this channel, in samples.
+        /// One for a mono buffer, the channel count for an interleaved one.
+        var stride: Int
+        var frames: Int
+    }
+
+    /// Tap channels the render path carries, which is what the layout named
+    /// capped by what the processor can hold.
+    private(set) var routedChannels = 2
+
+    /// Global output channel each tap channel is written to. -1 means dropped.
+    private(set) var destinations = Array(0..<EQProcessor.maxChannels)
+
+    /// Input buffer and channel each tap channel is read from.
+    private(set) var sourceBuffers = [Int](repeating: 0, count: EQProcessor.maxChannels)
+    private(set) var sourceChannels = Array(0..<EQProcessor.maxChannels)
+
+    /// Which input buffer the primary tap was described as occupying, and how
+    /// wide it is. Both are used to recognise it if the description turns out
+    /// not to fit the device.
+    private(set) var tapBufferIndex = 0
+    private(set) var tapChannelCount = 2
+
+    // MARK: - Configuration (render thread, from staged values)
+
+    mutating func setRouting(
+        channels: Int, destinations newDestinations: [Int], sourceBuffers newBuffers: [Int],
+        sourceChannels newChannels: [Int]
+    ) {
+        routedChannels = channels
+        for channel in 0..<channels {
+            destinations[channel] = newDestinations[channel]
+            sourceBuffers[channel] = newBuffers[channel]
+            sourceChannels[channel] = newChannels[channel]
+        }
+    }
+
+    mutating func setTapBuffer(_ index: Int) { tapBufferIndex = index }
+    mutating func setTapChannelCount(_ count: Int) { tapChannelCount = count }
+
+    /// Whether a proposed routing differs from the one in force, which is what
+    /// decides if the delay lines are describing audio that is no longer there.
+    func differs(
+        channels: Int, destinations other: [Int], sourceBuffers otherBuffers: [Int],
+        sourceChannels otherChannels: [Int]
+    ) -> Bool {
+        guard channels == routedChannels else { return true }
+        for channel in 0..<channels
+        where other[channel] != destinations[channel]
+            || otherBuffers[channel] != sourceBuffers[channel]
+            || otherChannels[channel] != sourceChannels[channel]
+        {
+            return true
+        }
+        return false
+    }
+
+    // MARK: - Placing audio (render thread)
+
+    /// Copies each routed channel from the input channel the layout names to the
+    /// output channel it names, and returns how many frames were written.
+    ///
+    /// Source and destination are both explicit. With one tap every source is
+    /// the same buffer and the channels are read in order; with one tap per
+    /// output stream they are not, and nothing here needs to know which case it
+    /// is in.
+    func place(
+        _ inABL: UnsafeMutableAudioBufferListPointer,
+        into outABL: UnsafeMutableAudioBufferListPointer,
+        substitute: Int?
+    ) -> Int {
+        var written = 0
+        for channel in 0..<routedChannels {
+            guard let source = origin(of: channel, in: inABL, substitute: substitute),
+                let target = destination(of: destinations[channel], in: outABL)
+            else { continue }
+            let count = min(source.frames, target.frames)
+            var read = source.pointer
+            var sink = target.pointer
+            for _ in 0..<count {
+                sink.pointee = read.pointee
+                read += source.stride
+                sink += target.stride
+            }
+            written = max(written, count)
+        }
+        return written
+    }
+
+    /// Where routed channel `index` ended up in the output list, or nil when the
+    /// device has no such channel.
+    func output(
+        of index: Int, in outABL: UnsafeMutableAudioBufferListPointer
+    ) -> Span? {
+        guard index >= 0, index < routedChannels else { return nil }
+        return destination(of: destinations[index], in: outABL)
+    }
+
+    /// Locates one routed channel in the input list: which buffer it is in,
+    /// where it starts, and how far apart its samples are. The mirror of
+    /// `destination`, and nil on the same terms — a channel the input does not
+    /// have is left silent rather than read from nowhere.
+    private func origin(
+        of channel: Int, in inABL: UnsafeMutableAudioBufferListPointer, substitute: Int?
+    ) -> (pointer: UnsafePointer<Float>, stride: Int, frames: Int)? {
+        var buffer = sourceBuffers[channel]
+        // The described buffer was not the tap, so the one the search found
+        // stands in for it — the old behaviour, kept for the taps it applies to.
+        if let substitute, buffer == tapBufferIndex { buffer = substitute }
+        guard buffer >= 0, buffer < inABL.count,
+            let data = inABL[buffer].mData?.assumingMemoryBound(to: Float.self)
+        else { return nil }
+        let channels = Int(inABL[buffer].mNumberChannels)
+        let source = sourceChannels[channel]
+        guard channels > 0, source >= 0, source < channels else { return nil }
+        let frames = Int(inABL[buffer].mDataByteSize) / (MemoryLayout<Float>.size * channels)
+        return (UnsafePointer(data + source), channels, frames)
+    }
+
+    /// Locates one global output channel: which buffer holds it, where in that
+    /// buffer it starts, and how far apart its samples are.
+    ///
+    /// Returns nil when the layout names a channel the device does not have,
+    /// which is the honest answer — better a silent channel than a write past
+    /// the end of a buffer.
+    private func destination(
+        of globalChannel: Int, in outABL: UnsafeMutableAudioBufferListPointer
+    ) -> Span? {
+        guard globalChannel >= 0 else { return nil }
+        var base = 0
+        for i in 0..<outABL.count {
+            let buffer = outABL[i]
+            let channels = Int(buffer.mNumberChannels)
+            guard channels > 0 else { continue }
+            if globalChannel < base + channels {
+                guard let data = buffer.mData?.assumingMemoryBound(to: Float.self) else {
+                    return nil
+                }
+                let frames = Int(buffer.mDataByteSize) / (MemoryLayout<Float>.size * channels)
+                return Span(
+                    pointer: data + (globalChannel - base), stride: channels, frames: frames)
+            }
+            base += channels
+        }
+        return nil
+    }
+
+    /// The buffer to read instead of the one the layout named, or nil when the
+    /// named one is right.
+    ///
+    /// Position is taken from the layout rather than searched for: the aggregate
+    /// lists its sub-device's input buffers before the taps', so it is known on
+    /// the main thread, where device properties may be read — see
+    /// `OutputPlan.tapBufferIndex`.
+    ///
+    /// Searching by channel count was wrong, and wrong in the quietest possible
+    /// way. A duplex output device presents an input stream of its own, and when
+    /// that stream is as wide as the tap it matches first: on BlackHole 16ch —
+    /// sixteen in, sixteen out — CoreEQ equalized the device's own silent input
+    /// and wrote silence to the speakers, while the tap went on muting every
+    /// other process. The engine reported `running` throughout.
+    ///
+    /// The search survives as the fallback. A description that does not fit the
+    /// device is a reason to look, not a reason to drop every block.
+    func substituteTapBuffer(in inABL: UnsafeMutableAudioBufferListPointer) -> Int? {
+        if tapBufferIndex >= 0, tapBufferIndex < inABL.count,
+            inABL[tapBufferIndex].mData != nil,
+            inABL[tapBufferIndex].mNumberChannels == UInt32(tapChannelCount)
+        {
+            return nil
+        }
+        for i in 0..<inABL.count
+        where inABL[i].mNumberChannels == UInt32(tapChannelCount) && inABL[i].mData != nil {
+            return i
+        }
+        for i in 0..<inABL.count
+        where inABL[i].mNumberChannels == UInt32(routedChannels) && inABL[i].mData != nil {
+            return i
+        }
+        for i in 0..<inABL.count where inABL[i].mData != nil {
+            return i
+        }
+        return nil
+    }
+}

--- a/CoreEQ/EQ/EQProcessor.swift
+++ b/CoreEQ/EQ/EQProcessor.swift
@@ -87,6 +87,15 @@ final class EQProcessor: @unchecked Sendable {
     nonisolated(unsafe) private(set) var peakLevel: Float = 0
     nonisolated(unsafe) private(set) var clippedSamples = 0
 
+    /// How long the tap has delivered nothing but digital zero.
+    ///
+    /// Reset by the first non-zero sample, so it measures the *current* run of
+    /// silence rather than a total. `IdlePolicy` uses it to decide when the
+    /// audio path can be released — which is why it counts exact zeros and not
+    /// "quiet": a passage at -60 dB is still someone listening, and tearing the
+    /// path down under them is the failure that matters here.
+    nonisolated(unsafe) private(set) var silentSeconds: Double = 0
+
     /// Mono copy of the played-back output, tapped for the spectrum analyzer.
     /// 8192 samples is well beyond the analyzer's 4096-sample window, so the
     /// consumer can snapshot without the producer overtaking the read region.
@@ -309,10 +318,22 @@ final class EQProcessor: @unchecked Sendable {
     }
 
     /// Forgets what the tap has delivered, for a fresh engine.
+    /// Clears filter state across a pause in the audio.
+    ///
+    /// The delay lines hold the last samples processed. Resuming after a gap
+    /// runs new audio against state that describes sound from minutes ago, which
+    /// is the same discontinuity a channel or rate change causes — and those
+    /// already reset. A few samples of transient is a click.
+    func prepareForResume() {
+        resetAllDelays()
+        silentSeconds = 0
+    }
+
     func resetAudioObservation() {
         hasReceivedAudio = false
         peakLevel = 0
         clippedSamples = 0
+        silentSeconds = 0
     }
 
     /// Stages the output layout. Set by `AudioEngine` once per engine start,
@@ -371,8 +392,19 @@ final class EQProcessor: @unchecked Sendable {
 
         // Watched whether or not anything is written: while the tap is being
         // proved this is the only thing the render path is here to do.
-        if !hasReceivedAudio, carriesSignal(inABL) {
+        let signal = carriesSignal(inABL)
+        if !hasReceivedAudio, signal {
             hasReceivedAudio = true
+        }
+        // Counted from the frames delivered rather than from a clock, so it
+        // stays true when the IO thread is late and stops advancing the moment
+        // the device stops calling us — which is what it means for there to be
+        // no audio at all.
+        if signal {
+            silentSeconds = 0
+        } else if sampleRate > 0, outABL.count > 0, outABL[0].mNumberChannels > 0 {
+            let bytesPerFrame = MemoryLayout<Float>.size * Int(outABL[0].mNumberChannels)
+            silentSeconds += Double(Int(outABL[0].mDataByteSize) / bytesPerFrame) / sampleRate
         }
 
         // Nothing is written while proving. The tap is unmuted then, so every

--- a/CoreEQ/EQ/EQProcessor.swift
+++ b/CoreEQ/EQ/EQProcessor.swift
@@ -45,19 +45,9 @@ final class EQProcessor: @unchecked Sendable {
 
     private static let smoothingSeconds = 0.05
 
-    /// Whether the tap has ever delivered anything but digital silence.
-    ///
-    /// Set on the render thread, read on the main one, and deliberately not
-    /// synchronised: it only ever goes false to true, a reader that sees the
-    /// old value simply asks again, and a lock on every block would cost more
-    /// than the fact is worth.
-    ///
-    /// It exists because a tap can be created without permission. It reports a
-    /// plausible format, the aggregate runs, the IO proc fires — and every
-    /// sample is zero, while `muteBehavior` silences every other process at the
-    /// hardware. Nothing in the Core Audio API tells that apart from a Mac that
-    /// happens to be quiet, so the engine watches for it instead.
-    nonisolated(unsafe) private(set) var hasReceivedAudio = false
+    /// What the render thread noticed, for the diagnostics report and for
+    /// `IdlePolicy`. See `RenderObservations` for why this is unsynchronised.
+    nonisolated(unsafe) private(set) var observed = RenderObservations()
 
     /// Whether the engine is still proving the tap works.
     ///
@@ -71,30 +61,6 @@ final class EQProcessor: @unchecked Sendable {
     /// block either side of the change is of no consequence — one buffer of
     /// silence, or one buffer unprocessed.
     nonisolated(unsafe) var isProvingCapture = false
-
-    /// The loudest sample the EQ has produced since the engine started, and how
-    /// many left the representable range.
-    ///
-    /// A boosted preset can ask for more headroom than the signal has, and the
-    /// result is distortion the user hears as noise rather than as loudness —
-    /// two reports of exactly that are open. Nothing else can settle it: the mix
-    /// level arriving at a tap is unknowable from inside it, so the only way to
-    /// know whether CoreEQ is clipping is to look at what CoreEQ produced.
-    ///
-    /// Unsynchronised for the same reasons as `hasReceivedAudio`: written only
-    /// on the render thread, read only for a report, and a reader that catches
-    /// a stale value is a reader who asks again.
-    nonisolated(unsafe) private(set) var peakLevel: Float = 0
-    nonisolated(unsafe) private(set) var clippedSamples = 0
-
-    /// How long the tap has delivered nothing but digital zero.
-    ///
-    /// Reset by the first non-zero sample, so it measures the *current* run of
-    /// silence rather than a total. `IdlePolicy` uses it to decide when the
-    /// audio path can be released — which is why it counts exact zeros and not
-    /// "quiet": a passage at -60 dB is still someone listening, and tearing the
-    /// path down under them is the failure that matters here.
-    nonisolated(unsafe) private(set) var silentSeconds: Double = 0
 
     /// Mono copy of the played-back output, tapped for the spectrum analyzer.
     /// 8192 samples is well beyond the analyzer's 4096-sample window, so the
@@ -187,42 +153,6 @@ final class EQProcessor: @unchecked Sendable {
     /// What the render thread needs to know about one filter: no identifier, no
     /// colour, no ladder slot. Plain data, so staging a chain is a fixed number
     /// of scalar copies into storage that already exists.
-    private struct FilterParameters: Equatable {
-        var kind = EQFilter.Kind.bell
-        var frequency = 1_000.0
-        var gain = 0.0
-        var q = 1.0
-        var isEnabled = true
-
-        init() {}
-
-        init(_ filter: EQFilter) {
-            kind = filter.kind
-            frequency = filter.frequency
-            gain = filter.gain
-            q = filter.q
-            isEnabled = filter.isEnabled
-        }
-
-        /// Whether a change here invalidates the coefficients and the filter's
-        /// delay line. Gain is excluded: it is ramped rather than jumped, so it
-        /// updates coefficients without discarding state.
-        func changesShape(from other: FilterParameters) -> Bool {
-            kind != other.kind
-                || frequency != other.frequency
-                || q != other.q
-                || isEnabled != other.isEnabled
-        }
-    }
-
-    private struct FilterState {
-        var parameters = FilterParameters()
-        var targetGain = 0.0
-        var currentGain = 0.0
-        var needsCoefficientUpdate = true
-        var filter = Biquad.identity
-    }
-
     // Staged parameters, written by the main thread under `lock` and consumed
     // by the render thread.
     //
@@ -234,8 +164,8 @@ final class EQProcessor: @unchecked Sendable {
     // times a second: unbounded in principle, and exactly the kind of thing that
     // shows up as a dropout under memory pressure rather than in testing.
     private let lock = OSAllocatedUnfairLock()
-    private var pendingFilters = [FilterParameters](
-        repeating: FilterParameters(), count: EQProcessor.maxFilters)
+    private var pendingFilters = [FilterBank.Parameters](
+        repeating: FilterBank.Parameters(), count: EQProcessor.maxFilters)
     /// Number of staged filters, or nil when no chain is waiting to be picked up.
     private var pendingFilterCount: Int?
     private var pendingPreamp: Double?
@@ -251,44 +181,22 @@ final class EQProcessor: @unchecked Sendable {
     private var pendingSourceChannels = Array(0..<EQProcessor.maxChannels)
 
     // Render-thread-only state.
-    private var filters = [FilterState](repeating: FilterState(), count: EQProcessor.maxFilters)
-    private var filterCount = 0
     /// Where a staged chain is copied to while the lock is held, so the lock is
     /// released before the longer work of comparing it against what is running.
     /// Holding it across that would put the main thread in a position to block
     /// on the audio thread, which is the inversion the staging exists to avoid.
-    private var stagedFilters = [FilterParameters](
-        repeating: FilterParameters(), count: EQProcessor.maxFilters)
+    private var stagedFilters = [FilterBank.Parameters](
+        repeating: FilterBank.Parameters(), count: EQProcessor.maxFilters)
     private var stagedDestinations = [Int](repeating: -1, count: EQProcessor.maxChannels)
     private var stagedSourceBuffers = [Int](repeating: 0, count: EQProcessor.maxChannels)
     private var stagedSourceChannels = Array(0..<EQProcessor.maxChannels)
-    private var sampleRate = 44_100.0
+    /// Where the tap's channels go and how they are found in the buffer lists.
+    /// See `BufferRouter`.
+    private var router = BufferRouter()
+    /// The chain itself, and everything the samples pass through. See
+    /// `FilterBank`.
+    private var bank = FilterBank()
     private var bypassed = false
-    /// Delay lines for every filter and channel, flat and allocated once:
-    /// filter-major, then channel, then the two states. Two per filter per
-    /// channel is what transposed direct form II needs.
-    private var delays = [Double](
-        repeating: 0, count: EQProcessor.maxFilters * EQProcessor.maxChannels * 2)
-    /// Where each tap channel is written, render-thread owned. -1 is "nowhere".
-    /// Defaults to the identity map, so a processor the engine has not described
-    /// yet behaves as plain interleaved audio rather than as silence.
-    private var destinations = Array(0..<EQProcessor.maxChannels)
-    /// Tap channels currently routed, never more than `destinations` holds.
-    private var routedChannels = 2
-    /// Input buffer the tap arrives in, render-thread owned. Zero is correct for
-    /// an output-only device, which presents no input buffers of its own.
-    private var tapBufferIndex = 0
-    /// Channels the tap delivers, *unclamped* — `routedChannels` is capped at
-    /// `maxChannels`, and recognising the tap needs its real width.
-    private var tapChannelCount = 2
-    /// Input buffer each routed channel is read from, render-thread owned.
-    private var sourceBuffers = [Int](repeating: 0, count: EQProcessor.maxChannels)
-    /// Channel within that buffer, render-thread owned.
-    private var sourceChannels = Array(0..<EQProcessor.maxChannels)
-    // Output trim, smoothed like the band gains so dragging the preamp slider
-    // is a fade rather than a step.
-    private var targetPreampLinear = 1.0
-    private var currentPreampLinear = 1.0
 
     // MARK: - Control (any thread)
 
@@ -296,10 +204,10 @@ final class EQProcessor: @unchecked Sendable {
     /// dropped here rather than in the callback, so the render side never has to
     /// reason about a chain longer than its storage.
     func setFilters(_ newFilters: [EQFilter]) {
-        let count = min(newFilters.count, Self.maxFilters)
+        let count = min(newFilters.count, FilterBank.maxFilters)
         lock.lock()
         for i in 0..<count {
-            pendingFilters[i] = FilterParameters(newFilters[i])
+            pendingFilters[i] = FilterBank.Parameters(newFilters[i])
         }
         pendingFilterCount = count
         lock.unlock()
@@ -325,15 +233,12 @@ final class EQProcessor: @unchecked Sendable {
     /// is the same discontinuity a channel or rate change causes — and those
     /// already reset. A few samples of transient is a click.
     func prepareForResume() {
-        resetAllDelays()
-        silentSeconds = 0
+        bank.resetAll()
+        observed.silentSeconds = 0
     }
 
     func resetAudioObservation() {
-        hasReceivedAudio = false
-        peakLevel = 0
-        clippedSamples = 0
-        silentSeconds = 0
+        observed.reset()
     }
 
     /// Stages the output layout. Set by `AudioEngine` once per engine start,
@@ -392,20 +297,16 @@ final class EQProcessor: @unchecked Sendable {
 
         // Watched whether or not anything is written: while the tap is being
         // proved this is the only thing the render path is here to do.
-        let signal = carriesSignal(inABL)
-        if !hasReceivedAudio, signal {
-            hasReceivedAudio = true
-        }
-        // Counted from the frames delivered rather than from a clock, so it
-        // stays true when the IO thread is late and stops advancing the moment
-        // the device stops calling us — which is what it means for there to be
-        // no audio at all.
-        if signal {
-            silentSeconds = 0
-        } else if sampleRate > 0, outABL.count > 0, outABL[0].mNumberChannels > 0 {
+        // Time is counted from the frames delivered rather than from a clock,
+        // so it stays true when the IO thread is late and stops advancing the
+        // moment the device stops calling us — which is what it means for there
+        // to be no audio at all.
+        var elapsed = 0.0
+        if bank.sampleRate > 0, outABL.count > 0, outABL[0].mNumberChannels > 0 {
             let bytesPerFrame = MemoryLayout<Float>.size * Int(outABL[0].mNumberChannels)
-            silentSeconds += Double(Int(outABL[0].mDataByteSize) / bytesPerFrame) / sampleRate
+            elapsed = Double(Int(outABL[0].mDataByteSize) / bytesPerFrame) / bank.sampleRate
         }
+        observed.observe(input: inABL, seconds: elapsed)
 
         // Nothing is written while proving. The tap is unmuted then, so every
         // other process is still audible and adding our copy would double it.
@@ -416,11 +317,11 @@ final class EQProcessor: @unchecked Sendable {
 
         // Where the primary tap actually turned up, which may not be where it
         // was described. Resolved once per block rather than per channel.
-        let substitute = substituteTapBuffer(in: inABL)
-        let placed = place(inABL, into: outABL, substitute: substitute)
+        let substitute = router.substituteTapBuffer(in: inABL)
+        let placed = router.place(inABL, into: outABL, substitute: substitute)
 
         if !bypassed, placed > 0 {
-            advanceSmoothing(frames: placed)
+            bank.advance(frames: placed)
             equalize(outABL, frames: placed)
         }
 
@@ -431,19 +332,6 @@ final class EQProcessor: @unchecked Sendable {
     ///
     /// Stops at the first one, so on a Mac that is playing this costs a single
     /// comparison — and it is only called until the answer is yes.
-    private func carriesSignal(_ abl: UnsafeMutableAudioBufferListPointer) -> Bool {
-        for i in 0..<abl.count {
-            guard let data = abl[i].mData?.assumingMemoryBound(to: Float.self) else {
-                continue
-            }
-            let count = Int(abl[i].mDataByteSize) / MemoryLayout<Float>.size
-            for sample in 0..<count where data[sample] != 0 {
-                return true
-            }
-        }
-        return false
-    }
-
     /// Copies each routed channel from the input channel the layout names to the
     /// output channel it names, and returns how many frames were written.
     ///
@@ -451,63 +339,22 @@ final class EQProcessor: @unchecked Sendable {
     /// the same buffer and the channels are read in order; with one tap per
     /// output stream they are not, and nothing here needs to know which case it
     /// is in.
-    private func place(
-        _ inABL: UnsafeMutableAudioBufferListPointer,
-        into outABL: UnsafeMutableAudioBufferListPointer,
-        substitute: Int?
-    ) -> Int {
-        var written = 0
-        for channel in 0..<routedChannels {
-            guard let source = origin(of: channel, in: inABL, substitute: substitute),
-                let target = destination(of: destinations[channel], in: outABL)
-            else { continue }
-            let count = min(source.frames, target.frames)
-            var read = source.pointer
-            var sink = target.pointer
-            for _ in 0..<count {
-                sink.pointee = read.pointee
-                read += source.stride
-                sink += target.stride
-            }
-            written = max(written, count)
-        }
-        return written
-    }
-
     /// Locates one routed channel in the input list: which buffer it is in,
     /// where it starts, and how far apart its samples are. The mirror of
     /// `destination`, and nil on the same terms — a channel the input does not
     /// have is left silent rather than read from nowhere.
-    private func origin(
-        of channel: Int, in inABL: UnsafeMutableAudioBufferListPointer, substitute: Int?
-    ) -> (pointer: UnsafePointer<Float>, stride: Int, frames: Int)? {
-        var buffer = sourceBuffers[channel]
-        // The described buffer was not the tap, so the one the search found
-        // stands in for it — the old behaviour, kept for the taps it applies to.
-        if let substitute, buffer == tapBufferIndex { buffer = substitute }
-        guard buffer >= 0, buffer < inABL.count,
-            let data = inABL[buffer].mData?.assumingMemoryBound(to: Float.self)
-        else { return nil }
-        let channels = Int(inABL[buffer].mNumberChannels)
-        let source = sourceChannels[channel]
-        guard channels > 0, source >= 0, source < channels else { return nil }
-        let frames = Int(inABL[buffer].mDataByteSize) / (MemoryLayout<Float>.size * channels)
-        return (UnsafePointer(data + source), channels, frames)
-    }
-
     /// Runs the chain and the output trim over the channels the tap was placed
     /// into. The rest of the device's channels are silence and stay that way.
     private func equalize(
         _ outABL: UnsafeMutableAudioBufferListPointer, frames: Int
     ) {
-        for channel in 0..<routedChannels {
-            guard let target = destination(of: destinations[channel], in: outABL)
-            else { continue }
+        for channel in 0..<router.routedChannels {
+            guard let target = router.output(of: channel, in: outABL) else { continue }
             let count = min(frames, target.frames)
-            processChannel(
+            bank.process(
                 target.pointer, stride: target.stride, frames: count, channel: channel)
-            applyPreamp(target.pointer, stride: target.stride, frames: count)
-            measureLevel(target.pointer, stride: target.stride, frames: count)
+            bank.applyPreamp(target.pointer, stride: target.stride, frames: count)
+            observed.observe(output: target.pointer, stride: target.stride, frames: count)
         }
     }
 
@@ -518,49 +365,12 @@ final class EQProcessor: @unchecked Sendable {
     /// nothing worth the pass. The peak is kept for the life of the engine
     /// rather than per block — the question is whether this ever happened, and a
     /// value that decays answers it only for whoever is watching at the time.
-    private func measureLevel(
-        _ samples: UnsafePointer<Float>, stride: Int, frames: Int
-    ) {
-        var peak = peakLevel
-        var clipped = 0
-        var index = 0
-        for _ in 0..<frames {
-            let magnitude = abs(samples[index])
-            if magnitude > peak { peak = magnitude }
-            if magnitude > 1.0 { clipped &+= 1 }
-            index += stride
-        }
-        peakLevel = peak
-        clippedSamples &+= clipped
-    }
-
     /// Locates one global output channel: which buffer holds it, where in that
     /// buffer it starts, and how far apart its samples are.
     ///
     /// Returns nil when the layout names a channel the device does not have,
     /// which is the honest answer — better a silent channel than a write past
     /// the end of a buffer.
-    private func destination(
-        of globalChannel: Int, in outABL: UnsafeMutableAudioBufferListPointer
-    ) -> (pointer: UnsafeMutablePointer<Float>, stride: Int, frames: Int)? {
-        guard globalChannel >= 0 else { return nil }
-        var base = 0
-        for i in 0..<outABL.count {
-            let buffer = outABL[i]
-            let channels = Int(buffer.mNumberChannels)
-            guard channels > 0 else { continue }
-            if globalChannel < base + channels {
-                guard let data = buffer.mData?.assumingMemoryBound(to: Float.self) else {
-                    return nil
-                }
-                let frames = Int(buffer.mDataByteSize) / (MemoryLayout<Float>.size * channels)
-                return (data + (globalChannel - base), channels, frames)
-            }
-            base += channels
-        }
-        return nil
-    }
-
     /// The buffer to read instead of the one the layout named, or nil when the
     /// named one is right.
     ///
@@ -578,27 +388,6 @@ final class EQProcessor: @unchecked Sendable {
     ///
     /// The search survives as the fallback. A description that does not fit the
     /// device is a reason to look, not a reason to drop every block.
-    private func substituteTapBuffer(in inABL: UnsafeMutableAudioBufferListPointer) -> Int? {
-        if tapBufferIndex >= 0, tapBufferIndex < inABL.count,
-            inABL[tapBufferIndex].mData != nil,
-            inABL[tapBufferIndex].mNumberChannels == UInt32(tapChannelCount)
-        {
-            return nil
-        }
-        for i in 0..<inABL.count
-        where inABL[i].mNumberChannels == UInt32(tapChannelCount) && inABL[i].mData != nil {
-            return i
-        }
-        for i in 0..<inABL.count
-        where inABL[i].mNumberChannels == UInt32(routedChannels) && inABL[i].mData != nil {
-            return i
-        }
-        for i in 0..<inABL.count where inABL[i].mData != nil {
-            return i
-        }
-        return nil
-    }
-
     /// Hands a mono copy of the final output — equalized when enabled, the
     /// untouched passthrough when bypassed — to the spectrum buffer, so the
     /// analyzer always shows what is actually reaching the speakers.
@@ -606,13 +395,13 @@ final class EQProcessor: @unchecked Sendable {
     /// Reads the channels the audio was placed into rather than the head of the
     /// first buffer, which on a multichannel device is not where the audio is.
     private func feedSpectrum(_ outABL: UnsafeMutableAudioBufferListPointer) {
-        guard routedChannels > 0,
-            let left = destination(of: destinations[0], in: outABL), left.frames > 0
+        guard router.routedChannels > 0,
+            let left = router.output(of: 0, in: outABL), left.frames > 0
         else { return }
         // Average the pair when the map put it side by side in one buffer, which
         // is every interleaved device. Otherwise the first channel alone is an
         // honest enough picture for a backdrop.
-        let right = routedChannels > 1 ? destination(of: destinations[1], in: outABL) : nil
+        let right = router.routedChannels > 1 ? router.output(of: 1, in: outABL) : nil
         let adjacent = right.map { $0.pointer == left.pointer + 1 && $0.stride == left.stride }
         spectrumBuffer.write(
             interleaved: left.pointer,
@@ -625,23 +414,8 @@ final class EQProcessor: @unchecked Sendable {
     // MARK: - Render-thread helpers
 
     /// First of the two delay-line slots for one filter on one channel.
-    private func delayIndex(filter: Int, channel: Int) -> Int {
-        (filter * Self.maxChannels + channel) * 2
-    }
-
     /// Clears one filter's delay lines across every channel. Called when a
     /// filter's shape changes, because the state describes the old response.
-    private func resetDelays(filter: Int) {
-        let base = filter * Self.maxChannels * 2
-        for offset in 0..<(Self.maxChannels * 2) {
-            delays[base + offset] = 0
-        }
-    }
-
-    private func resetAllDelays() {
-        for i in 0..<delays.count { delays[i] = 0 }
-    }
-
     /// Notes this cycle's cadence for `RateWindow` to read later.
     ///
     /// The frame count comes from the output list rather than from anything the
@@ -660,7 +434,7 @@ final class EQProcessor: @unchecked Sendable {
             hostTime: timestamp.mHostTime,
             sampleTime: timestamp.mFlags.contains(.sampleTimeValid) ? timestamp.mSampleTime : 0,
             frames: frames,
-            configuredRate: sampleRate)
+            configuredRate: bank.sampleRate)
     }
 
     private func consumePendingParameters() {
@@ -695,160 +469,48 @@ final class EQProcessor: @unchecked Sendable {
         pendingTapChannelCount = nil
         lock.unlock()
 
-        if let newTapChannels { tapChannelCount = newTapChannels }
+        if let newTapChannels { router.setTapChannelCount(newTapChannels) }
 
-        if let newTapBuffer, newTapBuffer != tapBufferIndex {
-            tapBufferIndex = newTapBuffer
+        if let newTapBuffer, newTapBuffer != router.tapBufferIndex {
+            router.setTapBuffer(newTapBuffer)
             // A different input buffer is different audio, so the delay lines
             // are describing something that is no longer arriving.
-            resetAllDelays()
+            bank.resetAll()
         }
 
         if let newRouted {
-            var changed = newRouted != routedChannels
-            for channel in 0..<newRouted
-            where stagedDestinations[channel] != destinations[channel]
-                || stagedSourceBuffers[channel] != sourceBuffers[channel]
-                || stagedSourceChannels[channel] != sourceChannels[channel]
-            {
-                changed = true
-            }
+            let changed = router.differs(
+                channels: newRouted, destinations: stagedDestinations,
+                sourceBuffers: stagedSourceBuffers, sourceChannels: stagedSourceChannels)
             if changed {
-                routedChannels = newRouted
-                for channel in 0..<newRouted {
-                    destinations[channel] = stagedDestinations[channel]
-                    sourceBuffers[channel] = stagedSourceBuffers[channel]
-                    sourceChannels[channel] = stagedSourceChannels[channel]
-                }
+                router.setRouting(
+                    channels: newRouted, destinations: stagedDestinations,
+                    sourceBuffers: stagedSourceBuffers, sourceChannels: stagedSourceChannels)
                 // Different channels means the delay lines are describing audio
                 // that is no longer there.
-                resetAllDelays()
+                bank.resetAll()
             }
         }
 
-        if let newRate, newRate != sampleRate {
+        if let newRate, bank.setSampleRate(newRate) {
             // The far edge of the stale window, and the only place it can be
             // timed: everything before this point ran on the old coefficients.
             rateTrace.mark(.coefficientsRecomputed, rate: newRate)
-            sampleRate = newRate
-            for i in 0..<filterCount {
-                filters[i].needsCoefficientUpdate = true
-                resetDelays(filter: i)
-            }
         }
 
         if let newFilterCount {
-            filterCount = newFilterCount
-            for i in 0..<filterCount {
-                let staged = stagedFilters[i]
-                if staged.changesShape(from: filters[i].parameters) {
-                    filters[i].needsCoefficientUpdate = true
-                    resetDelays(filter: i)
-                }
-                filters[i].parameters = staged
-                // Switching a gain-bearing filter off ramps it to zero, which is
-                // the same smooth path a slider drag takes and lands on identity.
-                // High and low pass have no gain to ramp, so they switch at once.
-                filters[i].targetGain = staged.isEnabled ? staged.gain : 0
-            }
+            bank.setFilters(stagedFilters, count: newFilterCount)
         }
 
         if let newPreamp {
-            targetPreampLinear = pow(10.0, newPreamp / 20.0)
+            bank.setPreamp(dB: newPreamp)
         }
 
         if let newBypass, newBypass != bypassed {
             bypassed = newBypass
-            if !bypassed {
-                for i in 0..<filterCount { resetDelays(filter: i) }
-            }
-        }
-    }
-
-    /// Output trim, applied after every filter — this is the point of the chain
-    /// where headroom given away by boosting is taken back.
-    private func applyPreamp(
-        _ samples: UnsafeMutablePointer<Float>, stride: Int, frames: Int
-    ) {
-        guard currentPreampLinear != 1.0 else { return }
-        let gain = Float(currentPreampLinear)
-        var index = 0
-        for _ in 0..<frames {
-            samples[index] *= gain
-            index += stride
-        }
-    }
-
-    private func advanceSmoothing(frames: Int) {
-        let step = min(1.0, Double(frames) / (sampleRate * Self.smoothingSeconds))
-
-        if currentPreampLinear != targetPreampLinear {
-            let next = currentPreampLinear + (targetPreampLinear - currentPreampLinear) * step
-            currentPreampLinear =
-                abs(next - targetPreampLinear) < 0.0005 ? targetPreampLinear : next
-        }
-        for i in 0..<filterCount {
-            if filters[i].currentGain != filters[i].targetGain {
-                var gain =
-                    filters[i].currentGain + (filters[i].targetGain - filters[i].currentGain) * step
-                if abs(gain - filters[i].targetGain) < 0.02 {
-                    gain = filters[i].targetGain
-                }
-                filters[i].currentGain = gain
-                filters[i].needsCoefficientUpdate = true
-            }
-            if filters[i].needsCoefficientUpdate {
-                let parameters = filters[i].parameters
-                // Coefficients come from the same `Biquad` the response curve is
-                // drawn from, so the plot always matches the audio.
-                if !parameters.isEnabled, !parameters.kind.usesGain {
-                    filters[i].filter = .identity
-                } else {
-                    filters[i].filter = Biquad(
-                        kind: parameters.kind,
-                        frequency: parameters.frequency,
-                        gain: filters[i].currentGain,
-                        q: parameters.q,
-                        sampleRate: sampleRate
-                    )
-                }
-                filters[i].needsCoefficientUpdate = false
-            }
-        }
-    }
-
-    private func processChannel(
-        _ samples: UnsafeMutablePointer<Float>, stride: Int, frames: Int, channel: Int
-    ) {
-        for i in 0..<filterCount {
-            let filter = filters[i].filter
-            // Identity filters are the common case — every band the user has not
-            // touched — so skipping them keeps an untouched chain nearly free.
-            if filter == .identity { continue }
-            let b0 = filter.b0
-            let b1 = filter.b1
-            let b2 = filter.b2
-            let a1 = filter.a1
-            let a2 = filter.a2
-            let slot = delayIndex(filter: i, channel: channel)
-            var z1 = delays[slot]
-            var z2 = delays[slot + 1]
-
-            var index = 0
-            for _ in 0..<frames {
-                let x = Double(samples[index])
-                let y = b0 * x + z1
-                z1 = b1 * x - a1 * y + z2
-                z2 = b2 * x - a2 * y
-                samples[index] = Float(y)
-                index += stride
-            }
-
-            // Flush denormals so idle audio does not burn CPU.
-            if abs(z1) < 1e-15 { z1 = 0 }
-            if abs(z2) < 1e-15 { z2 = 0 }
-            delays[slot] = z1
-            delays[slot + 1] = z2
+            // Coming back from bypass, the delay lines describe audio from
+            // before it was switched off.
+            if !bypassed { bank.resetAll() }
         }
     }
 }

--- a/CoreEQ/EQ/FilterBank.swift
+++ b/CoreEQ/EQ/FilterBank.swift
@@ -1,0 +1,230 @@
+import Foundation
+
+/// The equalizer itself: a flat chain of biquads, run over every routed channel.
+///
+/// Everything about *where* audio comes from and goes to belongs to
+/// `BufferRouter`; everything about what happens to the samples in between is
+/// here. Kept apart because they fail differently — a routing mistake sends
+/// audio to the wrong place, a filter mistake makes it the wrong shape, and
+/// telling those apart in one 500 line type was harder than it needed to be.
+///
+/// The chain has no notion of bands, sliders, or ladders. It receives whatever
+/// the user's editing surfaces produced and runs every entry the same way, which
+/// is what makes CoreEQ's two editors two views of one equalizer.
+///
+/// A struct, stored inline by the processor. Every field here is touched on the
+/// audio thread, where a class would add a retain and an indirection per block.
+struct FilterBank {
+
+    /// Eleven ladder slots plus `BuiltInProfiles.maxFreeFilters`, with room left
+    /// for automatically generated processing later. Each filter is one more
+    /// pass over the buffer, so this is a real budget.
+    static let maxFilters = 32
+
+    /// How long a gain change takes to travel, so a profile switch is a fade
+    /// rather than a step.
+    private static let smoothingSeconds = 0.05
+
+    /// One filter, as the main thread describes it.
+    struct Parameters: Equatable {
+        var kind = EQFilter.Kind.bell
+        var frequency = 1_000.0
+        var gain = 0.0
+        var q = 1.0
+        var isEnabled = true
+
+        init() {}
+
+        init(_ filter: EQFilter) {
+            kind = filter.kind
+            frequency = filter.frequency
+            gain = filter.gain
+            q = filter.q
+            isEnabled = filter.isEnabled
+        }
+
+        /// Whether a change here invalidates the coefficients and the filter's
+        /// delay line. Gain is excluded: it is ramped rather than jumped, so it
+        /// updates coefficients without discarding state.
+        func changesShape(from other: Parameters) -> Bool {
+            kind != other.kind || frequency != other.frequency || q != other.q
+                || isEnabled != other.isEnabled
+        }
+    }
+
+    /// One filter, as the render thread holds it.
+    private struct State {
+        var parameters = Parameters()
+        var targetGain = 0.0
+        var currentGain = 0.0
+        var needsCoefficientUpdate = true
+        var filter = Biquad.identity
+    }
+
+    private(set) var sampleRate = 44_100.0
+
+    private var filters = [State](repeating: State(), count: FilterBank.maxFilters)
+    private var count = 0
+
+    /// Delay lines for every filter and channel, flat and allocated once:
+    /// filter-major, then channel, then the two states. Two per filter per
+    /// channel is what transposed direct form II needs.
+    private var delays = [Double](
+        repeating: 0, count: FilterBank.maxFilters * EQProcessor.maxChannels * 2)
+
+    /// Output trim, smoothed like the band gains so dragging the preamp slider
+    /// is a fade rather than a step.
+    private var targetPreampLinear = 1.0
+    private var currentPreampLinear = 1.0
+
+    // MARK: - Configuration (render thread, from staged values)
+
+    /// Adopts a new rate, returning whether it was one. Coefficients are a
+    /// function of `2πf/fs`, so every filter has to be rebuilt and every delay
+    /// line dropped — the state describes a response that no longer exists.
+    mutating func setSampleRate(_ rate: Double) -> Bool {
+        guard rate != sampleRate else { return false }
+        sampleRate = rate
+        for i in 0..<count {
+            filters[i].needsCoefficientUpdate = true
+            resetDelays(filter: i)
+        }
+        return true
+    }
+
+    mutating func setFilters(_ staged: [Parameters], count newCount: Int) {
+        count = newCount
+        for i in 0..<count {
+            let parameters = staged[i]
+            if parameters.changesShape(from: filters[i].parameters) {
+                filters[i].needsCoefficientUpdate = true
+                resetDelays(filter: i)
+            }
+            filters[i].parameters = parameters
+            // Switching a gain-bearing filter off ramps it to zero, which is the
+            // same smooth path a slider drag takes and lands on identity. High
+            // and low pass have no gain to ramp, so they switch at once.
+            filters[i].targetGain = parameters.isEnabled ? parameters.gain : 0
+        }
+    }
+
+    mutating func setPreamp(dB: Double) {
+        targetPreampLinear = pow(10.0, dB / 20.0)
+    }
+
+    /// Drops every delay line. For discontinuities the filters cannot know
+    /// about: a different set of channels, a different input buffer, a pause in
+    /// the audio, or coming back from bypass.
+    mutating func resetAll() {
+        for i in 0..<delays.count { delays[i] = 0 }
+    }
+
+    // MARK: - Running (render thread)
+
+    /// Moves gains and the trim one block closer to where they are going, and
+    /// rebuilds any coefficients that need it.
+    ///
+    /// Once per block rather than per channel: every channel shares the same
+    /// filter shapes, and rebuilding them per channel would be the same
+    /// arithmetic done `channels` times for the same answer.
+    mutating func advance(frames: Int) {
+        let step = min(1.0, Double(frames) / (sampleRate * Self.smoothingSeconds))
+
+        if currentPreampLinear != targetPreampLinear {
+            let next = currentPreampLinear + (targetPreampLinear - currentPreampLinear) * step
+            currentPreampLinear =
+                abs(next - targetPreampLinear) < 0.0005 ? targetPreampLinear : next
+        }
+        for i in 0..<count {
+            if filters[i].currentGain != filters[i].targetGain {
+                var gain =
+                    filters[i].currentGain + (filters[i].targetGain - filters[i].currentGain) * step
+                if abs(gain - filters[i].targetGain) < 0.02 {
+                    gain = filters[i].targetGain
+                }
+                filters[i].currentGain = gain
+                filters[i].needsCoefficientUpdate = true
+            }
+            if filters[i].needsCoefficientUpdate {
+                let parameters = filters[i].parameters
+                // Coefficients come from the same `Biquad` the response curve is
+                // drawn from, so the plot always matches the audio.
+                if !parameters.isEnabled, !parameters.kind.usesGain {
+                    filters[i].filter = .identity
+                } else {
+                    filters[i].filter = Biquad(
+                        kind: parameters.kind,
+                        frequency: parameters.frequency,
+                        gain: filters[i].currentGain,
+                        q: parameters.q,
+                        sampleRate: sampleRate
+                    )
+                }
+                filters[i].needsCoefficientUpdate = false
+            }
+        }
+    }
+
+    /// Runs the whole chain over one channel, in place.
+    mutating func process(
+        _ samples: UnsafeMutablePointer<Float>, stride: Int, frames: Int, channel: Int
+    ) {
+        for i in 0..<count {
+            let filter = filters[i].filter
+            // Identity filters are the common case — every band the user has not
+            // touched — so skipping them keeps an untouched chain nearly free.
+            if filter == .identity { continue }
+            let b0 = filter.b0
+            let b1 = filter.b1
+            let b2 = filter.b2
+            let a1 = filter.a1
+            let a2 = filter.a2
+            let slot = delayIndex(filter: i, channel: channel)
+            var z1 = delays[slot]
+            var z2 = delays[slot + 1]
+
+            var index = 0
+            for _ in 0..<frames {
+                let x = Double(samples[index])
+                let y = b0 * x + z1
+                z1 = b1 * x - a1 * y + z2
+                z2 = b2 * x - a2 * y
+                samples[index] = Float(y)
+                index += stride
+            }
+
+            // Flush denormals so idle audio does not burn CPU.
+            if abs(z1) < 1e-15 { z1 = 0 }
+            if abs(z2) < 1e-15 { z2 = 0 }
+            delays[slot] = z1
+            delays[slot + 1] = z2
+        }
+    }
+
+    /// Applies the output trim, in place.
+    func applyPreamp(_ samples: UnsafeMutablePointer<Float>, stride: Int, frames: Int) {
+        guard currentPreampLinear != 1.0 else { return }
+        let gain = Float(currentPreampLinear)
+        var index = 0
+        for _ in 0..<frames {
+            samples[index] *= gain
+            index += stride
+        }
+    }
+
+    // MARK: - Delay lines
+
+    /// First of the two delay-line slots for one filter on one channel.
+    private func delayIndex(filter: Int, channel: Int) -> Int {
+        (filter * EQProcessor.maxChannels + channel) * 2
+    }
+
+    /// Clears one filter's delay lines across every channel. Called when a
+    /// filter's shape changes, because the state describes the old response.
+    private mutating func resetDelays(filter: Int) {
+        let base = filter * EQProcessor.maxChannels * 2
+        for offset in 0..<(EQProcessor.maxChannels * 2) {
+            delays[base + offset] = 0
+        }
+    }
+}

--- a/CoreEQ/EQ/RenderObservations.swift
+++ b/CoreEQ/EQ/RenderObservations.swift
@@ -1,0 +1,107 @@
+import CoreAudio
+import Foundation
+
+/// What the render thread noticed, for whoever asks later.
+///
+/// None of this changes a sample. It exists because the render thread is the
+/// only place several questions can be answered at all — whether the tap is
+/// delivering anything, whether the chain is producing more than fits, how long
+/// the room has been quiet — and every one of them turned out to be the fact
+/// that settled a real defect. Kept together because they share a rule that
+/// nothing else in the processor shares: written on the audio thread, read from
+/// the main one, and deliberately unsynchronised.
+///
+/// That rule is safe for exactly these fields and would not be for the audio
+/// state. Each is a single word, written by one thread and read by another that
+/// only ever draws a report with it; a reader that catches a stale value asks
+/// again a moment later and gets the new one. A lock on every block would cost
+/// more than the facts are worth, and a lock on the audio thread is the thing
+/// the whole design is arranged to avoid.
+struct RenderObservations {
+
+    /// Whether the tap has ever delivered anything but digital silence.
+    ///
+    /// It exists because a tap can be created without permission. It reports a
+    /// plausible format, the aggregate runs, the IO proc fires — and every
+    /// sample is zero, while `muteBehavior` silences every other process at the
+    /// hardware. Nothing in the Core Audio API tells that apart from a Mac that
+    /// happens to be quiet, so the engine watches for it instead.
+    var hasReceivedAudio = false
+
+    /// How long the tap has delivered nothing but digital zero.
+    ///
+    /// Reset by the first non-zero sample, so it measures the *current* run of
+    /// silence rather than a total. `IdlePolicy` uses it to decide when the
+    /// audio path can be released — which is why it counts exact zeros and not
+    /// "quiet": a passage at -60 dB is still someone listening, and stopping
+    /// under them is the failure that matters here.
+    var silentSeconds: Double = 0
+
+    /// The loudest sample the EQ has produced since the engine started, and how
+    /// many left the representable range.
+    ///
+    /// A boosted preset can ask for more headroom than the signal has, and the
+    /// result is distortion the user hears as noise rather than as loudness.
+    /// Nothing else can settle it: the mix level arriving at a tap is unknowable
+    /// from inside it, so the only way to know whether CoreEQ is clipping is to
+    /// look at what CoreEQ produced.
+    var peakLevel: Float = 0
+    var clippedSamples = 0
+
+    /// Forgets everything. Called when the engine starts, because every one of
+    /// these is a claim about the audio path that is now being rebuilt.
+    mutating func reset() {
+        hasReceivedAudio = false
+        silentSeconds = 0
+        peakLevel = 0
+        clippedSamples = 0
+    }
+
+    /// Notes a block of input: whether it carried anything, and how much time
+    /// passed if it did not.
+    mutating func observe(input: UnsafeMutableAudioBufferListPointer, seconds: Double) {
+        let signal = Self.carriesSignal(input)
+        if signal {
+            hasReceivedAudio = true
+            silentSeconds = 0
+        } else {
+            silentSeconds += seconds
+        }
+    }
+
+    /// Notes what the chain produced on one channel.
+    ///
+    /// The peak is kept for the life of the engine rather than per block — the
+    /// question is whether this ever happened, and a value that decays answers
+    /// it only for whoever is watching at the time.
+    mutating func observe(output samples: UnsafePointer<Float>, stride: Int, frames: Int) {
+        var peak = peakLevel
+        var clipped = 0
+        var index = 0
+        for _ in 0..<frames {
+            let magnitude = abs(samples[index])
+            if magnitude > peak { peak = magnitude }
+            if magnitude > 1.0 { clipped &+= 1 }
+            index += stride
+        }
+        peakLevel = peak
+        clippedSamples &+= clipped
+    }
+
+    /// Whether any buffer holds a sample that is not zero.
+    ///
+    /// Stops at the first one, so on a Mac that is playing this costs a single
+    /// comparison.
+    private static func carriesSignal(_ abl: UnsafeMutableAudioBufferListPointer) -> Bool {
+        for i in 0..<abl.count {
+            guard let data = abl[i].mData?.assumingMemoryBound(to: Float.self) else {
+                continue
+            }
+            let count = Int(abl[i].mDataByteSize) / MemoryLayout<Float>.size
+            for sample in 0..<count where data[sample] != 0 {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/CoreEQ/UI/MainWindow/FilterListView.swift
+++ b/CoreEQ/UI/MainWindow/FilterListView.swift
@@ -133,23 +133,48 @@ struct FilterListView: View {
                     ScrollView(.vertical) {
                         LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
                             Section {
-                                ForEach(
-                                    Array(profileManager.freeFilters.enumerated()), id: \.element.id
-                                ) { index, filter in
-                                    FilterRowView(
-                                        index: index + 1,
-                                        filter: filter,
-                                        isSelected: selectedFilterID == filter.id,
-                                        isEnabled: isEnabled,
-                                        profileManager: profileManager
-                                    )
-                                    .onTapGesture { selectedFilterID = filter.id }
+                                // The rows themselves are *not* lazy, and that is
+                                // about Tab rather than about drawing. A lazy
+                                // container only builds what is on screen, and a
+                                // field that has not been built is not in the
+                                // window's key-view loop — so tabbing off the
+                                // last visible row wrapped to the first row
+                                // instead of moving to the next one. Bands are
+                                // capped at `maxFreeFilters`, so building all of
+                                // them costs nothing worth having.
+                                //
+                                // The outer stack stays lazy because that is what
+                                // carries `pinnedViews`, and the pinned titles
+                                // are why the header is inside the scroll view at
+                                // all.
+                                VStack(spacing: 0) {
+                                    ForEach(
+                                        Array(profileManager.freeFilters.enumerated()),
+                                        id: \.element.id
+                                    ) { index, filter in
+                                        // One view per row, always. Emitting the
+                                        // row and then sometimes a separator made
+                                        // the last iteration a different shape
+                                        // from every other, which is exactly the
+                                        // sort of thing view identity is built
+                                        // from.
+                                        VStack(spacing: 0) {
+                                            FilterRowView(
+                                                index: index + 1,
+                                                filter: filter,
+                                                isSelected: selectedFilterID == filter.id,
+                                                isEnabled: isEnabled,
+                                                profileManager: profileManager
+                                            )
+                                            .onTapGesture { selectedFilterID = filter.id }
 
-                                    if filter.id != profileManager.freeFilters.last?.id {
-                                        Rectangle()
-                                            .fill(Theme.blockBorder)
-                                            .frame(height: Theme.FilterRow.separator)
-                                            .padding(.leading, 8)
+                                            if filter.id != profileManager.freeFilters.last?.id {
+                                                Rectangle()
+                                                    .fill(Theme.blockBorder)
+                                                    .frame(height: Theme.FilterRow.separator)
+                                                    .padding(.leading, 8)
+                                            }
+                                        }
                                     }
                                 }
                             } header: {

--- a/CoreEQ/UI/Settings/DiagnosticsSettingsView.swift
+++ b/CoreEQ/UI/Settings/DiagnosticsSettingsView.swift
@@ -120,6 +120,7 @@ struct DiagnosticsSettingsView: View {
         snapshot.uptime = EngineStatusBridge.shared.uptime
         snapshot.restarts = EngineStatusBridge.shared.restarts
         snapshot.level = EngineStatusBridge.shared.level
+        snapshot.idling = EngineStatusBridge.shared.idling
         return snapshot
     }
 

--- a/CoreEQ/UI/Settings/GeneralSettingsView.swift
+++ b/CoreEQ/UI/Settings/GeneralSettingsView.swift
@@ -60,6 +60,19 @@ struct GeneralSettingsView: View {
             }
 
             Section {
+                Toggle("Release the audio device when nothing is playing", isOn: idleBinding)
+                    .help("Lets the Mac sleep on schedule while CoreEQ is running")
+            } footer: {
+                Text(
+                    "Holding the audio device keeps a Mac awake. CoreEQ lets go after half a "
+                        + "minute of silence and takes it back the moment something plays. Turn "
+                        + "this off if your audio misbehaves."
+                )
+                .font(Theme.Font.label)
+                .foregroundStyle(.secondary)
+            }
+
+            Section {
                 // Laid out here rather than with `LabeledContent`, which places
                 // its value column on its own alignment and insets — that is
                 // what left the button at a different margin from every other
@@ -182,6 +195,17 @@ struct GeneralSettingsView: View {
     }
 
     // MARK: - Login item
+
+    /// Written straight to `SettingsStore`, and read by the engine on its next
+    /// idle check rather than pushed. Half a second late is invisible for a
+    /// setting, and it keeps the settings scene from needing the engine — which
+    /// it cannot be handed, being a separate scene.
+    private var idleBinding: Binding<Bool> {
+        Binding(
+            get: { SettingsStore().pausesWhenSilent },
+            set: { SettingsStore().pausesWhenSilent = $0 }
+        )
+    }
 
     private var loginItemBinding: Binding<Bool> {
         Binding(

--- a/CoreEQTests/App/SettingsStoreTests.swift
+++ b/CoreEQTests/App/SettingsStoreTests.swift
@@ -124,4 +124,15 @@ import Testing
         #expect(reopened.userProfiles.isEmpty)
         #expect(reopened.deviceStates.isEmpty)
     }
+    /// On unless the user says otherwise. The default matters: it decides
+    /// whether a Mac that has played anything once ever sleeps again.
+    @Test func releasingTheDeviceIsOnByDefault() {
+        #expect(settings.pausesWhenSilent)
+    }
+
+    @Test func theIdleSettingSurvivesARelaunch() {
+        settings.pausesWhenSilent = false
+        #expect(SettingsStore(defaults: defaults).pausesWhenSilent == false)
+    }
+
 }

--- a/CoreEQTests/Audio/Capture/DiagnosticsReportTests.swift
+++ b/CoreEQTests/Audio/Capture/DiagnosticsReportTests.swift
@@ -334,4 +334,35 @@ struct DiagnosticsReportTests {
         }
     }
 
+    // MARK: - Idling
+
+    /// An idle engine and a broken one look identical from outside: the EQ is
+    /// on, nothing is playing, and no sound is being processed. The report is
+    /// the only thing that can tell them apart, so it has to say which.
+    @Test func anIdleEngineIsNamedAsSuch() {
+        var idle = engine()
+        idle.idling = DiagnosticsReport.Idling(isIdle: true, releases: 4, totalSeconds: 900)
+
+        #expect(text(engine: idle).contains("idling:          YES"))
+    }
+
+    @Test func aRunningEngineReportsItsIdleHistory() {
+        var running = engine()
+        running.idling = DiagnosticsReport.Idling(isIdle: false, releases: 4, totalSeconds: 900)
+
+        let report = text(engine: running)
+
+        #expect(report.contains("idling:          no, 4 release(s)"))
+        #expect(report.contains("15 min total"))
+    }
+
+    /// The escape hatch has to be visible in the report. Someone who turned it
+    /// off and forgot would otherwise file a sleep bug that cannot be explained.
+    @Test func theDisabledSettingIsReported() {
+        var pinned = engine()
+        pinned.idling = DiagnosticsReport.Idling(isIdle: false, isEnabled: false)
+
+        #expect(text(engine: pinned).contains("idling:          off"))
+    }
+
 }

--- a/CoreEQTests/Audio/Capture/IdlePolicyTests.swift
+++ b/CoreEQTests/Audio/Capture/IdlePolicyTests.swift
@@ -1,0 +1,188 @@
+import Foundation
+import Testing
+
+/// When the audio path may be torn down, and when it must not be.
+///
+/// The upside of getting this right is a Mac that sleeps. The downside of
+/// getting it wrong is the defect this app has already shipped three times: no
+/// sound, and every layer reporting success. So the rules that protect against
+/// that are stated first, and stated as rules rather than as examples.
+struct IdlePolicyTests {
+
+    private func verdict(
+        isRunning: Bool = true,
+        silentSeconds: TimeInterval = 0,
+        isAnythingPlaying: Bool = false,
+        isEnabled: Bool = true,
+        isCaptureProven: Bool = true,
+        pausesWhenSilent: Bool = true,
+        isAudioStarting: Bool = false,
+        isRecovering: Bool = false
+    ) -> IdlePolicy.Verdict {
+        IdlePolicy.evaluate(
+            isRunning: isRunning, silentSeconds: silentSeconds,
+            isAnythingPlaying: isAnythingPlaying, isEnabled: isEnabled,
+            isCaptureProven: isCaptureProven, pausesWhenSilent: pausesWhenSilent,
+            isAudioStarting: isAudioStarting, isRecovering: isRecovering)
+    }
+
+    // MARK: - What must never happen
+
+    /// Audio is arriving. Nothing below may tear the path down under it.
+    @Test func aPathCarryingAudioIsNeverTornDown() {
+        for silent in [0.0, 0.5, 5, 29, 29.999] {
+            #expect(verdict(silentSeconds: silent) == .keepRunning, "torn down after \(silent)s")
+        }
+    }
+
+    /// Before the tap has been proved, silence is not evidence of quiet — it is
+    /// equally the sound of a refused permission. Idling on it would tear down
+    /// the path that has to run for the answer to arrive, and the engine would
+    /// never learn anything.
+    @Test func anUnprovenTapIsNeverIdled() {
+        #expect(verdict(silentSeconds: 600, isCaptureProven: false) == .keepRunning)
+    }
+
+    /// The user's switch wins over every rule. Every silent-Mac defect in this
+    /// app's history had no workaround from inside the app; this one does, and
+    /// it has to hold in both directions.
+    @Test func theSettingOverridesEveryOtherRule() {
+        #expect(verdict(silentSeconds: 9_999, pausesWhenSilent: false) == .keepRunning)
+        #expect(
+            verdict(isRunning: false, isAnythingPlaying: false, pausesWhenSilent: false) == .resume)
+    }
+
+    /// A path that cannot be built must not be built twice a second.
+    ///
+    /// Found by testing on hardware, not by reading: after a resume that fails,
+    /// the engine is neither running nor idle, so the resume rule fires again on
+    /// the next poll, and an output device the engine refuses would be retried
+    /// at the poll interval for as long as the app ran. Recovery belongs to the
+    /// retry that already has a backoff and a ceiling.
+    @Test func aFailedPathIsLeftToItsOwnRetry() {
+        #expect(verdict(isRunning: false, isAnythingPlaying: true, isRecovering: true) == .stayIdle)
+        #expect(verdict(silentSeconds: 600, isRecovering: true) == .keepRunning)
+    }
+
+    // MARK: - Going idle
+
+    /// The point of the whole thing: after long enough silence, let go of the
+    /// device so the machine can sleep.
+    @Test func longSilenceReleasesTheDevice() {
+        #expect(verdict(silentSeconds: 30) == .goIdle)
+        #expect(verdict(silentSeconds: 600) == .goIdle)
+    }
+
+    /// A process holding the device open while sending zeros is the state where
+    /// the two signals disagree. Measured on this machine the system signal is
+    /// clean — nothing reports output while nothing plays — but the engine must
+    /// not depend on that, because the consequence of trusting it is a rebuild
+    /// every thirty seconds.
+    @Test func silenceAloneDoesNotIdleWhileSomethingHoldsTheDevice() {
+        #expect(verdict(silentSeconds: 600, isAnythingPlaying: true) == .keepRunning)
+    }
+
+    /// Switched off there is nothing to process, so the device is released at
+    /// once rather than after the silence timer — the audio path would exist
+    /// only to pass audio through untouched.
+    @Test func beingSwitchedOffReleasesTheDeviceImmediately() {
+        #expect(verdict(silentSeconds: 0, isEnabled: false) == .goIdle)
+    }
+
+    /// The threshold is a floor, not a window: it does not stop being true.
+    @Test func theVerdictIsStableOnceSilenceIsLongEnough() {
+        var seconds = 30.0
+        while seconds < 10_000 {
+            #expect(verdict(silentSeconds: seconds) == .goIdle)
+            seconds *= 2
+        }
+    }
+
+    // MARK: - Coming back
+
+    /// The one signal available while idle: the render path is gone, so the
+    /// system has to be asked.
+    @Test func somethingPlayingBringsThePathBack() {
+        #expect(verdict(isRunning: false, isAnythingPlaying: true) == .resume)
+    }
+
+    /// Coming back *before* the first sample is the whole point. A process
+    /// announcing itself arrives about 80 ms before it plays and the device
+    /// needs about 90 ms to start, so waiting for audio to be audible before
+    /// reacting is already too late — that is what a second of unequalized
+    /// playback was.
+    @Test func anAnnouncementIsEnoughToComeBack() {
+        let announced = verdict(
+            isRunning: false, isAnythingPlaying: false, isAudioStarting: true)
+        #expect(announced == .resume)
+    }
+
+    /// It is a hint, not an override. Switched off there is still nothing to
+    /// come back for, and a failed path is still left to its own retry.
+    @Test func anAnnouncementDoesNotOverrideTheRulesAboveIt() {
+        #expect(
+            verdict(isRunning: false, isEnabled: false, isAudioStarting: true) == .stayIdle)
+        #expect(
+            verdict(isRunning: false, isAudioStarting: true, isRecovering: true) == .stayIdle)
+    }
+
+    /// While running it means nothing — the engine is already up.
+    @Test func anAnnouncementDoesNotDisturbARunningEngine() {
+        #expect(verdict(silentSeconds: 600, isAudioStarting: true) == .goIdle)
+    }
+
+    @Test func aQuietMacStaysIdle() {
+        #expect(verdict(isRunning: false, isAnythingPlaying: false) == .stayIdle)
+    }
+
+    /// Switched off, there is nothing to come back for even when audio plays.
+    /// Resuming would build the whole path to pass audio through unchanged, and
+    /// take the assertion back with it.
+    @Test func playbackWhileSwitchedOffDoesNotResume() {
+        #expect(verdict(isRunning: false, isAnythingPlaying: true, isEnabled: false) == .stayIdle)
+    }
+
+    /// Silence measured before the teardown says nothing about the world after
+    /// it, and must not keep the engine from coming back.
+    @Test func staleSilenceDoesNotBlockAResume() {
+        #expect(
+            verdict(isRunning: false, silentSeconds: 9_999, isAnythingPlaying: true) == .resume)
+    }
+
+    // MARK: - Stability
+
+    /// A verdict has to be a function of the state, not of the order states
+    /// arrived in: the same inputs twice give the same answer, so the engine
+    /// cannot be walked into oscillating by an unlucky sequence.
+    @Test func theSameStateAlwaysGivesTheSameVerdict() {
+        for running in [true, false] {
+            for silent in [0.0, 29, 30, 120] {
+                for playing in [true, false] {
+                    for enabled in [true, false] {
+                        let first = verdict(
+                            isRunning: running, silentSeconds: silent,
+                            isAnythingPlaying: playing, isEnabled: enabled)
+                        let second = verdict(
+                            isRunning: running, silentSeconds: silent,
+                            isAnythingPlaying: playing, isEnabled: enabled)
+                        #expect(first == second)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Idling and resuming must not both be true of one moment. Silence is
+    /// measured by the render path and playback by the system, and the two can
+    /// disagree — a process can hold the device open while sending zeros. If
+    /// that disagreement produced "go idle" and "resume" in turn, the engine
+    /// would rebuild the audio path several times a second forever.
+    @Test func noStateBothIdlesAndResumes() {
+        for silent in [0.0, 30, 600] {
+            let running = verdict(isRunning: true, silentSeconds: silent, isAnythingPlaying: true)
+            guard running == .goIdle else { continue }
+            let idle = verdict(isRunning: false, silentSeconds: silent, isAnythingPlaying: true)
+            #expect(idle != .resume, "silence says idle while playback says resume: it will thrash")
+        }
+    }
+}

--- a/CoreEQTests/EQ/EQProcessorTests.swift
+++ b/CoreEQTests/EQ/EQProcessorTests.swift
@@ -1314,4 +1314,142 @@ struct EQProcessorTests {
         }
     }
 
+    // MARK: - Silence, which decides when the device is released
+
+    /// The measurement the whole idle behaviour rests on. Too eager and the
+    /// audio path is released under someone listening; too reluctant and the
+    /// Mac never sleeps, which is the bug it exists to fix.
+
+    /// Counted from frames delivered, not from a clock. The render thread has no
+    /// business reading the time, and frames are what the device actually did.
+    @Test func silenceIsMeasuredInDeliveredAudio() {
+        let processor = makeProcessor()
+        let oneSecond = Int(sampleRate)
+
+        _ = render(processor, [Float](repeating: 0, count: oneSecond))
+
+        #expect(abs(processor.silentSeconds - 1.0) < 0.001)
+    }
+
+    /// It accumulates across passes, because a device delivers a few hundred
+    /// frames at a time and thirty seconds of quiet is thousands of those.
+    @Test func silenceAccumulatesAcrossRenderPasses() {
+        let processor = makeProcessor()
+        let block = [Float](repeating: 0, count: 512)
+
+        for _ in 0..<100 { _ = render(processor, block) }
+
+        #expect(abs(processor.silentSeconds - 100 * 512 / sampleRate) < 0.001)
+    }
+
+    /// Any sample at all ends the silence. Not a threshold: a passage at -60 dB
+    /// is still someone listening, and releasing the device under them is the
+    /// failure that matters.
+    @Test func aSingleQuietSampleEndsTheSilence() {
+        let processor = makeProcessor()
+        _ = render(processor, [Float](repeating: 0, count: 4_800))
+        #expect(processor.silentSeconds > 0)
+
+        var barelyAudible = [Float](repeating: 0, count: 4_800)
+        barelyAudible[2_000] = 1e-6
+        _ = render(processor, barelyAudible)
+
+        #expect(processor.silentSeconds == 0, "a quiet passage was counted as silence")
+    }
+
+    /// And music certainly does.
+    @Test func audioKeepsTheSilenceAtZero() {
+        let processor = makeProcessor()
+        for _ in 0..<20 { _ = render(processor, sine(440, frames: 512)) }
+
+        #expect(processor.silentSeconds == 0)
+    }
+
+    /// Silence restarts after audio rather than resuming where it left off:
+    /// what matters is the *current* run of quiet, not the total.
+    @Test func silenceIsTheCurrentRunNotATotal() {
+        let processor = makeProcessor()
+        _ = render(processor, [Float](repeating: 0, count: 24_000))
+        _ = render(processor, sine(440, frames: 512))
+        _ = render(processor, [Float](repeating: 0, count: 4_800))
+
+        #expect(abs(processor.silentSeconds - 4_800 / sampleRate) < 0.001)
+    }
+
+    /// Resuming clears it. The engine has just been stopped for a while, and
+    /// carrying the silence across would idle again on the next check —
+    /// releasing the device moments after taking it back.
+    @Test func resumingClearsTheSilence() {
+        let processor = makeProcessor()
+        _ = render(processor, [Float](repeating: 0, count: Int(sampleRate) * 40))
+        #expect(processor.silentSeconds > 30)
+
+        processor.prepareForResume()
+
+        #expect(processor.silentSeconds == 0)
+    }
+
+    /// Resuming also clears filter state, because the delay lines describe audio
+    /// from before the pause. Fed silence, a chain holding state rings; a chain
+    /// that was reset is silent.
+    @Test func resumingClearsFilterState() {
+        let processor = makeProcessor(filters: [
+            EQFilter(kind: .bell, frequency: 1_000, gain: 12, q: 8)
+        ])
+        _ = render(processor, sine(1_000, frames: 2_048, amplitude: 0.9))
+
+        processor.prepareForResume()
+        let afterReset = render(processor, [Float](repeating: 0, count: 512))
+
+        #expect(afterReset.allSatisfy { $0 == 0 }, "stale filter state rang into the new audio")
+    }
+
+    // MARK: - Output level, which settles the noise reports
+
+    /// The peak is kept for the life of the engine, not per block. The question
+    /// a report answers is whether this ever happened, and a value that decays
+    /// answers it only for whoever is watching at the time.
+    @Test func thePeakSurvivesLaterQuiet() {
+        let processor = makeProcessor()
+        _ = render(processor, sine(440, frames: 512, amplitude: 0.8))
+        let loud = processor.peakLevel
+        #expect(loud > 0.5)
+
+        for _ in 0..<50 { _ = render(processor, [Float](repeating: 0, count: 512)) }
+
+        #expect(processor.peakLevel == loud, "the peak decayed and stopped being evidence")
+    }
+
+    /// Clipping is what a boosted preset does to material that had no headroom,
+    /// and it is the first hypothesis for the open "sounds noisy" reports.
+    @Test func aBoostedChainReportsWhatDidNotFit() {
+        let processor = makeProcessor(
+            filters: [EQFilter(kind: .bell, frequency: 1_000, gain: 12, q: 1)])
+        for _ in 0..<20 { _ = render(processor, sine(1_000, frames: 512, amplitude: 0.95)) }
+
+        #expect(processor.peakLevel > 1.0)
+        #expect(processor.clippedSamples > 0)
+    }
+
+    /// A chain with headroom reports none, so the line means something when it
+    /// is not empty.
+    @Test func anUnboostedChainReportsNoClipping() {
+        let processor = makeProcessor()
+        for _ in 0..<20 { _ = render(processor, sine(1_000, frames: 512, amplitude: 0.5)) }
+
+        #expect(processor.clippedSamples == 0)
+        #expect(processor.peakLevel <= 1.0)
+    }
+
+    /// Bypass touches nothing, so there is nothing CoreEQ could have clipped —
+    /// and measuring it would blame the app for the material.
+    @Test func bypassMeasuresNothing() {
+        let processor = makeProcessor(
+            filters: [EQFilter(kind: .bell, frequency: 1_000, gain: 12, q: 1)])
+        processor.setBypassed(true)
+        for _ in 0..<20 { _ = render(processor, sine(1_000, frames: 512, amplitude: 0.95)) }
+
+        #expect(processor.clippedSamples == 0)
+    }
+
 }

--- a/CoreEQTests/EQ/EQProcessorTests.swift
+++ b/CoreEQTests/EQ/EQProcessorTests.swift
@@ -1328,7 +1328,7 @@ struct EQProcessorTests {
 
         _ = render(processor, [Float](repeating: 0, count: oneSecond))
 
-        #expect(abs(processor.silentSeconds - 1.0) < 0.001)
+        #expect(abs(processor.observed.silentSeconds - 1.0) < 0.001)
     }
 
     /// It accumulates across passes, because a device delivers a few hundred
@@ -1339,7 +1339,7 @@ struct EQProcessorTests {
 
         for _ in 0..<100 { _ = render(processor, block) }
 
-        #expect(abs(processor.silentSeconds - 100 * 512 / sampleRate) < 0.001)
+        #expect(abs(processor.observed.silentSeconds - 100 * 512 / sampleRate) < 0.001)
     }
 
     /// Any sample at all ends the silence. Not a threshold: a passage at -60 dB
@@ -1348,13 +1348,13 @@ struct EQProcessorTests {
     @Test func aSingleQuietSampleEndsTheSilence() {
         let processor = makeProcessor()
         _ = render(processor, [Float](repeating: 0, count: 4_800))
-        #expect(processor.silentSeconds > 0)
+        #expect(processor.observed.silentSeconds > 0)
 
         var barelyAudible = [Float](repeating: 0, count: 4_800)
         barelyAudible[2_000] = 1e-6
         _ = render(processor, barelyAudible)
 
-        #expect(processor.silentSeconds == 0, "a quiet passage was counted as silence")
+        #expect(processor.observed.silentSeconds == 0, "a quiet passage was counted as silence")
     }
 
     /// And music certainly does.
@@ -1362,7 +1362,7 @@ struct EQProcessorTests {
         let processor = makeProcessor()
         for _ in 0..<20 { _ = render(processor, sine(440, frames: 512)) }
 
-        #expect(processor.silentSeconds == 0)
+        #expect(processor.observed.silentSeconds == 0)
     }
 
     /// Silence restarts after audio rather than resuming where it left off:
@@ -1373,7 +1373,7 @@ struct EQProcessorTests {
         _ = render(processor, sine(440, frames: 512))
         _ = render(processor, [Float](repeating: 0, count: 4_800))
 
-        #expect(abs(processor.silentSeconds - 4_800 / sampleRate) < 0.001)
+        #expect(abs(processor.observed.silentSeconds - 4_800 / sampleRate) < 0.001)
     }
 
     /// Resuming clears it. The engine has just been stopped for a while, and
@@ -1382,11 +1382,11 @@ struct EQProcessorTests {
     @Test func resumingClearsTheSilence() {
         let processor = makeProcessor()
         _ = render(processor, [Float](repeating: 0, count: Int(sampleRate) * 40))
-        #expect(processor.silentSeconds > 30)
+        #expect(processor.observed.silentSeconds > 30)
 
         processor.prepareForResume()
 
-        #expect(processor.silentSeconds == 0)
+        #expect(processor.observed.silentSeconds == 0)
     }
 
     /// Resuming also clears filter state, because the delay lines describe audio
@@ -1412,12 +1412,12 @@ struct EQProcessorTests {
     @Test func thePeakSurvivesLaterQuiet() {
         let processor = makeProcessor()
         _ = render(processor, sine(440, frames: 512, amplitude: 0.8))
-        let loud = processor.peakLevel
+        let loud = processor.observed.peakLevel
         #expect(loud > 0.5)
 
         for _ in 0..<50 { _ = render(processor, [Float](repeating: 0, count: 512)) }
 
-        #expect(processor.peakLevel == loud, "the peak decayed and stopped being evidence")
+        #expect(processor.observed.peakLevel == loud, "the peak decayed and stopped being evidence")
     }
 
     /// Clipping is what a boosted preset does to material that had no headroom,
@@ -1427,8 +1427,8 @@ struct EQProcessorTests {
             filters: [EQFilter(kind: .bell, frequency: 1_000, gain: 12, q: 1)])
         for _ in 0..<20 { _ = render(processor, sine(1_000, frames: 512, amplitude: 0.95)) }
 
-        #expect(processor.peakLevel > 1.0)
-        #expect(processor.clippedSamples > 0)
+        #expect(processor.observed.peakLevel > 1.0)
+        #expect(processor.observed.clippedSamples > 0)
     }
 
     /// A chain with headroom reports none, so the line means something when it
@@ -1437,8 +1437,8 @@ struct EQProcessorTests {
         let processor = makeProcessor()
         for _ in 0..<20 { _ = render(processor, sine(1_000, frames: 512, amplitude: 0.5)) }
 
-        #expect(processor.clippedSamples == 0)
-        #expect(processor.peakLevel <= 1.0)
+        #expect(processor.observed.clippedSamples == 0)
+        #expect(processor.observed.peakLevel <= 1.0)
     }
 
     /// Bypass touches nothing, so there is nothing CoreEQ could have clipped —
@@ -1449,7 +1449,7 @@ struct EQProcessorTests {
         processor.setBypassed(true)
         for _ in 0..<20 { _ = render(processor, sine(1_000, frames: 512, amplitude: 0.95)) }
 
-        #expect(processor.clippedSamples == 0)
+        #expect(processor.observed.clippedSamples == 0)
     }
 
 }

--- a/docs/DEVELOPMENT.org
+++ b/docs/DEVELOPMENT.org
@@ -512,6 +512,62 @@ Implemented in =AudioEngine.swift=:
    cycle, runs it through =EQProcessor=, and writes it to the real device's
    output buffers.
 
+*** Releasing the device when nothing is playing
+
+A started aggregate makes =coreaudiod= hold a =PreventUserIdleSystemSleep=
+assertion for CoreEQ. Core Audio raises it on the first sound and never drops
+it, so a Mac that played anything once is held awake until CoreEQ quits.
+
+=IdlePolicy= decides when to let go; =AudioEngine= only carries it out. Every
+condition lives in the policy because it can be tested there against invented
+sequences, and the cost of a wrong condition is the failure this app has shipped
+three times — no sound, with every layer reporting success.
+
+Three things about it are load-bearing and should not be simplified away:
+
+- *Only the IO proc is stopped.* The tap and the aggregate stay alive, and this
+  is the rule most likely to be "improved" back into a bug. Tearing the path
+  down and rebuilding it on resume looks safer and is not: rebuilding creates a
+  new aggregate around the output device exactly as a player is opening it, so
+  the device is reconfigured — renegotiated, on Bluetooth — underneath the
+  client that just grabbed it. That shipped as far as manual testing and broke
+  playback outright: players failed to start and only succeeded after several
+  attempts, each attempt racing the rebuild.
+
+  The argument for tearing down was that a live =mutedWhenTapped= tap would
+  silence every other process with nothing running to write their audio back.
+  Measured, it does not: with the IO proc stopped and the tap alive, other
+  audio reaches the device at full level. The assumption was never tested, and
+  it cost a working feature.
+- *Silence and playback must both agree* before releasing. They come from
+  different places — the render path and the system — and a process may hold the
+  device open while sending zeros. Acting on either alone makes =goIdle= and
+  =resume= reachable from one state, and the path is rebuilt every thirty
+  seconds forever.
+- *A failed path is left to its own retry.* Otherwise a device the engine
+  refuses is retried at the poll interval rather than with the backoff and
+  ceiling that already exist.
+
+How the engine learns that audio is starting is itself measured, and the
+obvious answer is wrong. =kAudioProcessPropertyIsRunningOutput= sends *no
+notifications*: attached to every audio process, it never fired once. Sweeping
+those processes by hand answers the question but costs about 6 ms a pass, which
+rules out polling it quickly. =kAudioDevicePropertyDeviceIsRunningSomewhere= on
+the output device does notify, costs 0.05 ms to read, and reads false while
+CoreEQ is idle — so it says precisely "somebody else wants this device". A
+listener on the audio process list runs alongside it, because a process appears
+there about 80 ms before it plays, and the device needs about 90 ms to deliver
+its first buffer after being started. Acting on the announcement rather than on
+the audio is what closes the gap.
+
+Measured on a Bluetooth headset, resume went from 1.97 / 1.10 / 0.29 s of
+unequalized audio at a half-second poll to a consistent 40-48 ms.
+
+=Status= is deliberately unchanged while idle: nothing has changed for the user,
+and an idle engine reporting itself stopped would blink the menu bar icon off
+whenever a room went quiet. The diagnostics report carries the fact instead,
+because a released device and a broken engine look identical from outside.
+
 *** Sample rate changes, and why there is no stale window
 
 Coefficients are a function of =2pi*f/fs=, so a device that changes rate while

--- a/docs/DEVELOPMENT.org
+++ b/docs/DEVELOPMENT.org
@@ -691,6 +691,25 @@ while the window is still being assembled, so =AppDelegate= holds the
 =NSSplitViewController= rather than reaching for it through =mainWindow=, which is
 not assigned yet at that point.
 
+** A trap: a hand-made window does not update its Tab order
+
+=NSWindow.autorecalculatesKeyViewLoop= defaults to *false* for a window created
+in code, and to true only for one loaded from a nib. The main window is built by
+hand in =AppDelegate=, so with the default AppKit worked out the key-view loop
+once, at build time, and never revisited it. Any control added later — a
+parametric band, which is the whole point of that editor — had fields Tab had
+never heard of, so tabbing off the last row it knew about wrapped to the top.
+
+It presents as a bug about the *last* row, which sends you looking at the list
+and its separators. The give-away is that the same number of bands behaves
+differently depending on how you got there: adding a fourth leaves it broken,
+while adding a fifth and removing it again fixes it, because removing a view
+invalidates the loop and forces the rebuild that adding one does not. A symptom
+that depends on history rather than on state is a stale cache, not a layout
+mistake.
+
+Set it once, where the window is built.
+
 ** A trap: publishing from inside a view update
 
 A segmented =Picker= synchronises its selection while SwiftUI is updating the

--- a/docs/DEVELOPMENT.org
+++ b/docs/DEVELOPMENT.org
@@ -348,7 +348,10 @@ CoreEQ/
       SpectrumAnalyzer.swift  Windowed FFT driving the response backdrop
       SpectrumAudioBuffer.swift Lock-light ring buffer feeding the analyzer
   EQ/
-    EQProcessor.swift       Realtime biquad chain with parameter smoothing
+    EQProcessor.swift       The render path: staging, and what happens per block
+    BufferRouter.swift      Tap channels into device channels; buffer arithmetic
+    FilterBank.swift        The chain itself: biquads, smoothing, delay lines
+    RenderObservations.swift What the render thread noticed, for reports
     Biquad.swift            One RBJ biquad: coefficients + magnitude response
     AutoGain.swift          The trim that holds a preset at its original loudness
   Presets/
@@ -431,6 +434,20 @@ between a directory's sources and its tests is legible at a glance —
 accurate statement that the Core Audio boundary has no unit tests and cannot
 have them. The exception is =CoreEQTests/Support/=, which holds helpers rather
 than suites.
+
+*How the render path is divided.* =EQProcessor= owns the thread boundary — the
+staged parameters, the lock, and the order of work in a block — and delegates
+the rest. =BufferRouter= knows where audio comes from and goes to; =FilterBank=
+knows what happens to it in between; =RenderObservations= knows what was
+noticed on the way past. They are structs, stored inline, because everything
+here runs on the audio thread where a class would add a retain and an
+indirection per block.
+
+The staging deliberately did *not* move. It is what the type's
+=@unchecked Sendable= claim is about, and splitting it would mean either
+allocating a changes struct inside the IO callback or threading =inout=
+plumbing through it — spreading an invariant that is currently verifiable in
+one place, for no gain.
 
 *Where model logic lives.* =ProfileManager= is the only observable object in
 the model layer, and it is deliberately not where the thinking happens. The

--- a/docs/RELEASE_NOTES.org
+++ b/docs/RELEASE_NOTES.org
@@ -233,3 +233,110 @@ unsigned turned an event older than the trace into 768614336339369 ms, and
 =os_log= truncated the 500-row table away exactly where the interesting rows
 were. The summary now goes to the log and the table to a file, and only when
 there is a window to explain.
+
+** Preventing the Mac from sleeping
+
+Reported publicly: Activity Monitor shows CoreEQ preventing sleep, with no audio
+playing at all.
+
+*Both explanations this item carried were wrong*, and measuring was the only way
+to find that out. The first said a continuously running IOProc holds the
+machine awake. The second, written after a partial measurement, said the
+assertion is held simply because the aggregate has been started. Neither
+survives the full sequence:
+
+| moment                                   | assertion | IO cycles |
+|------------------------------------------+-----------+-----------|
+| engine running, nothing has ever played   | none      | 0         |
+| audio playing                             | held      | ~87/s     |
+| 30 s after the audio stopped              | held      | ~87/s     |
+| a minute after the audio stopped          | held      | ~87/s     |
+
+Core Audio does not spin the IO context up until something plays — *and then
+never spins it back down*. So the defect is not that CoreEQ holds the device
+from launch. It is that **once anything has played, the device is never let go**,
+which in practice is every session after the first sound.
+
+The assertion itself belongs to =coreaudiod=, raised for CoreEQ's aggregate and
+attributed back to CoreEQ's pid. That is why Activity Monitor blames an app
+whose own source contains no assertion, and why looking for one found nothing.
+
+*Fixed.* CoreEQ now releases the audio device after thirty seconds of digital
+silence and rebuilds it the moment something plays. Two measurements made that
+affordable: =AudioDeviceStop= alone releases the assertion, and a complete cold
+rebuild — tap, aggregate, IO proc — costs 27 ms. Observed resume in the running
+app was 42 ms.
+
+Only the IO proc is stopped. The tap and the aggregate stay alive, so resuming
+touches no topology at all — one =AudioDeviceStart= against a device that was
+never taken apart.
+
+It was built the other way first, tearing the whole path down and rebuilding it
+on resume, on the theory that a live =mutedWhenTapped= tap would silence every
+other process with nothing running to write their audio back. That theory was
+never tested, and it was wrong: measured, audio reaches the device at full level
+with the IO proc stopped and the tap alive. Worse, the rebuild it justified
+*broke playback*. Creating a new aggregate around the output device at the
+moment a player opens that device reconfigures the device — and renegotiates the
+link, on Bluetooth — underneath the client that just grabbed it. Players failed
+to start and only worked after several attempts, each one racing the rebuild.
+Found in manual testing on Bluetooth, where it is worst.
+
+The lesson is not about aggregates. An unexamined assumption about a failure
+mode produced a design that caused a different, real failure, and the check that
+would have settled it took one probe.
+
+*How the engine notices playback was the second thing testing corrected.* The
+first version polled every half second, and that left roughly a second of
+unequalized audio at the start of playback — clearly audible, and the whole
+point of an equalizer is that the first second is not wrong. The fix was not a
+faster poll: sweeping every audio process costs about 6 ms a pass, and
+=kAudioProcessPropertyIsRunningOutput= turns out to send no notifications at
+all, which is why an earlier listener-based attempt did nothing.
+
+=kAudioDevicePropertyDeviceIsRunningSomewhere= on the output device does notify,
+costs 0.05 ms to read, and is false while CoreEQ is idle. Beside it, a listener
+on the audio process list catches a player about 80 ms before it plays — useful,
+because the device needs about 90 ms to deliver its first buffer after being
+started, so reacting to *audible* audio is already too late.
+
+On a Bluetooth headset that took resume from 1.97 / 1.10 / 0.29 seconds down to
+a consistent 40-48 ms, measured from the player launching rather than from the
+first sample — which means the engine is running before there is anything to
+equalize.
+
+Two rules keep it from misbehaving, and both came out of testing rather than
+design. Silence and playback must *both* agree before the device is released:
+they are measured differently — one by the render path, one by the system — and
+a process is free to hold the device open while sending zeros, which would
+otherwise idle and resume in turn, rebuilding the audio path every thirty
+seconds for as long as that process ran. And a path that failed to build is left
+to the retry that already owns recovery: without that, an output device the
+engine refuses would be retried twice a second forever. The second was found on
+hardware, after the code looked right.
+
+A third came out of manual testing and is the one worth remembering, because it
+would have shipped the whole feature dead. The guard against acting mid-rebuild
+read =pendingRestart == nil=, and =pendingRestart= was cancelled everywhere but
+never *cleared* — so after the first restart the engine believed one was
+permanently in flight and never idled again. The default output device listener
+fires once at launch, so that first restart happens in every session: the
+feature would have worked in testing on a quiet machine and for nobody in the
+field. A work item used as a flag has to be nil'd wherever it can end, which is
+three places, not one.
+
+It was diagnosed from a pasted diagnostics report in a single step — =idling:
+no, 0 release(s) this session= beside a minute of uptime — which is the whole
+argument for the report carrying this in the first place.
+
+Idling is invisible from the outside — the EQ is on, and the next sound is
+equalized — so =Status= is deliberately untouched and the menu bar icon does not
+blink off every time a room goes quiet. What is visible is the diagnostics
+report, which now says whether the device is currently released, how many times
+it has been, and how long that has totalled. It has to: a released device and a
+broken engine look identical until someone plays something.
+
+There is also a switch, in Settings, to turn the whole behaviour off. Every
+silent-Mac defect in this app's history had no workaround from inside the app —
+quitting was the only fix, which is not discoverable for something that launches
+at login. One line of settings turns the next one into an inconvenience.

--- a/docs/RELEASE_NOTES.org
+++ b/docs/RELEASE_NOTES.org
@@ -340,3 +340,18 @@ There is also a switch, in Settings, to turn the whole behaviour off. Every
 silent-Mac defect in this app's history had no workaround from inside the app —
 quitting was the only fix, which is not discoverable for something that launches
 at login. One line of settings turns the next one into an inconvenience.
+
+** Tab skipped newly added parametric bands
+
+Reported while testing something else: adding a band, clicking into its first
+field and pressing Tab jumped to the top of the table instead of moving along
+the row.
+
+=NSWindow.autorecalculatesKeyViewLoop= defaults to false for a window built in
+code rather than loaded from a nib, so AppKit computed the Tab order once, when
+the window was made, and never again. Every band added afterwards had fields
+that were not in it.
+
+*Fixed*, in one line where the window is built. The details are in
+[[file:DEVELOPMENT.org][DEVELOPMENT.org]] under the traps, because the symptom — Tab skips the last row —
+points at the list, and the list is not where the fault is.

--- a/docs/ROADMAP.org
+++ b/docs/ROADMAP.org
@@ -31,8 +31,8 @@ fourth suspicion — that a Bluetooth route change left a window of audio filter
 at the wrong sample rate — was measured and turned out not to happen; it is in
 the release notes with the numbers.
 
-What is left here: audio arriving twice and every screen capture tool failing, a
-Mac kept awake indefinitely, and two smaller reports. They affect people doing
+What is left here: audio arriving twice and every screen capture tool failing,
+and two smaller reports. They affect people doing
 nothing unusual, none can be worked around from inside the app, and nothing else
 ships until they are fixed.
 
@@ -100,52 +100,6 @@ Three things to do:
 - When a second system-audio tool genuinely is present, detect it and say so
   plainly in the UI rather than leaving the user to work out why their audio
   sounds doubled.
-
-** Preventing the Mac from sleeping
-
-Activity Monitor shows CoreEQ preventing sleep, and it does so with no audio
-playing at all.
-
-The cause is not an assertion in CoreEQ's own code — there isn't one. It is the
-IO proc: =AudioDeviceStart= runs the aggregate continuously from launch, by
-design, since global bypass “keeps the engine running but passes audio through”
-(=AudioEngine.swift:49=). A continuously running IOProc is active audio IO as
-far as the system is concerned, so the assertion follows automatically.
-
-*That explanation is wrong, and the real one is narrower.* Measured while
-investigating the route-change window: with the engine running and nothing
-playing, =RateTrace= recorded *no IO cycles at all* over twenty-two seconds, on
-the Jabra and again on the built-in speakers. The render callback is not being
-called. So it is not a continuously running IOProc.
-
-=pmset -g assertions=, taken at the same moment, names what it actually is:
-
-#+begin_example
-pid 401(coreaudiod): PreventUserIdleSystemSleep named:
-  "com.apple.audio.com.andreypudov.coreeq.aggregate.<uid>.context.preventuseridlesleep"
-  Created for PID: 36385.
-  Resources: audio-in audio-out BuiltInSpeakerDevice
-#+end_example
-
-The assertion belongs to *coreaudiod*, raised for CoreEQ's aggregate device and
-attributed back to CoreEQ's pid — which is why Activity Monitor blames an app
-whose own source contains no assertion, and why searching that source for one
-found nothing. It is held because the aggregate has been *started*, not because
-audio is flowing: it was there with zero callbacks in twenty-two seconds.
-
-That changes the fix. Making the IO path idle-aware achieves nothing, because it
-is already idle. The assertion goes away only by stopping the aggregate
-(=AudioDeviceStop=) when nothing is playing and starting it again on demand,
-which is a real design change: something has to notice playback beginning, the
-restart has to be fast enough not to clip the first moment of it, and the tap's
-mute behaviour has to survive the cycle. Worth doing, and worth its own design
-rather than an afternoon.
-
-The fix is to stop running when there is nothing to do: tear the IO proc down
-when the app is bypassed, and when the mix has been silent for long enough that
-restarting on the next sample is cheaper than holding the machine awake. The
-constraint is that starting back up has to be fast and seamless enough that the
-first second of playback is not lost.
 
 ** Documentation that answers the repeated questions
 


### PR DESCRIPTION
Reported publicly: CoreEQ prevents sleep, with no audio playing.

Measured, the cause is narrower than the roadmap assumed. coreaudiod holds a
`PreventUserIdleSystemSleep` assertion for CoreEQ's aggregate, and Core Audio
spins the IO context up on the first sound and **never spins it back down** — so
every session after the first sound holds the machine awake indefinitely.

CoreEQ now stops its IO proc after 30 seconds of digital silence and starts it
again the moment anything wants the device. Resume measured at 40 ms on a
Bluetooth headset.

Two things testing corrected, both recorded in the docs:

- **Only the IO proc is stopped.** Tearing the path down and rebuilding it broke
  playback outright on Bluetooth — rebuilding creates an aggregate around the
  device just as a player is opening it. The theory that justified it, that a
  live muting tap would silence the Mac, was never tested and is false.
- **Detection is push, not poll.** A half-second poll left ~1 s of unequalized
  audio. `kAudioProcessPropertyIsRunningOutput` sends no notifications at all;
  `kAudioDevicePropertyDeviceIsRunningSomewhere` does, and costs 0.05 ms.

There's a Settings switch to turn it off, and the diagnostics report says whether
the device is currently released — a released device and a broken engine look
identical until someone plays something.

Also here: `EQProcessor` split into `BufferRouter`, `FilterBank` and
`RenderObservations` (behaviour-preserving, 235 lines of code left from 498), and
a Tab-order fix — `autorecalculatesKeyViewLoop` defaults to false for a window
built in code, so newly added parametric bands were not in the key-view loop.

458 tests.