### PR TITLE
~ tell clipping the equalizer caused from clipping it was handed

### DIFF
--- a/CoreEQ/Audio/AudioEngine.swift
+++ b/CoreEQ/Audio/AudioEngine.swift
@@ -125,7 +125,9 @@ final class AudioEngine: ObservableObject {
     /// fit.
     var level: DiagnosticsReport.Level {
         DiagnosticsReport.Level(
-            peak: processor.observed.peakLevel, clippedSamples: processor.observed.clippedSamples)
+            peak: processor.observed.peakLevel,
+            clippedSamples: processor.observed.clippedSamples,
+            sourcePeak: processor.observed.sourcePeakLevel)
     }
 
     /// Whether the audio device has been let go, and the history of that.

--- a/CoreEQ/Audio/Capture/DiagnosticsReport.swift
+++ b/CoreEQ/Audio/Capture/DiagnosticsReport.swift
@@ -56,6 +56,10 @@ enum DiagnosticsReport {
         /// signal did not fit.
         var peak: Float = 0
         var clippedSamples: Int = 0
+        /// Loudest sample the chain was handed. Above 1.0 means the material
+        /// itself arrived over full scale, which is not CoreEQ's doing — and
+        /// telling those two apart is the whole reason both are here.
+        var sourcePeak: Float = 0
 
         var isClipping: Bool { clippedSamples > 0 }
     }
@@ -230,6 +234,12 @@ enum DiagnosticsReport {
                     format: "  peak output:     %.2f%@", engine.level.peak,
                     engine.level.isClipping
                         ? " — \(engine.level.clippedSamples) sample(s) clipped" : ", no clipping"))
+            lines.append(String(format: "  peak in:         %.2f", engine.level.sourcePeak))
+            if engine.level.sourcePeak > 1.0 {
+                lines.append(
+                    "                   NOTE: the audio arrived above full scale. Anything at "
+                        + "or below that level is the material's, not CoreEQ's.")
+            }
             if engine.level.isClipping {
                 lines.append(
                     "                   NOTE: the chain produces more than fits, which is heard")

--- a/CoreEQ/EQ/BufferRouter.swift
+++ b/CoreEQ/EQ/BufferRouter.swift
@@ -89,12 +89,24 @@ struct BufferRouter {
     /// the same buffer and the channels are read in order; with one tap per
     /// output stream they are not, and nothing here needs to know which case it
     /// is in.
+    /// What one pass of `place` moved.
+    struct Placement {
+        var frames = 0
+        /// Loudest source sample copied, which is what the chain was handed.
+        ///
+        /// Taken here because this is the only place that touches exactly the
+        /// samples which become CoreEQ's output — not the whole input list,
+        /// which on a duplex device also carries the device's own input, and a
+        /// live microphone in it would read as a loud source.
+        var sourcePeak: Float = 0
+    }
+
     func place(
         _ inABL: UnsafeMutableAudioBufferListPointer,
         into outABL: UnsafeMutableAudioBufferListPointer,
         substitute: Int?
-    ) -> Int {
-        var written = 0
+    ) -> Placement {
+        var placement = Placement()
         for channel in 0..<routedChannels {
             guard let source = origin(of: channel, in: inABL, substitute: substitute),
                 let target = destination(of: destinations[channel], in: outABL)
@@ -103,13 +115,16 @@ struct BufferRouter {
             var read = source.pointer
             var sink = target.pointer
             for _ in 0..<count {
-                sink.pointee = read.pointee
+                let sample = read.pointee
+                sink.pointee = sample
+                let magnitude = abs(sample)
+                if magnitude > placement.sourcePeak { placement.sourcePeak = magnitude }
                 read += source.stride
                 sink += target.stride
             }
-            written = max(written, count)
+            placement.frames = max(placement.frames, count)
         }
-        return written
+        return placement
     }
 
     /// Where routed channel `index` ended up in the output list, or nil when the

--- a/CoreEQ/EQ/EQProcessor.swift
+++ b/CoreEQ/EQ/EQProcessor.swift
@@ -319,10 +319,11 @@ final class EQProcessor: @unchecked Sendable {
         // was described. Resolved once per block rather than per channel.
         let substitute = router.substituteTapBuffer(in: inABL)
         let placed = router.place(inABL, into: outABL, substitute: substitute)
+        observed.note(sourcePeak: placed.sourcePeak)
 
-        if !bypassed, placed > 0 {
-            bank.advance(frames: placed)
-            equalize(outABL, frames: placed)
+        if !bypassed, placed.frames > 0 {
+            bank.advance(frames: placed.frames)
+            equalize(outABL, frames: placed.frames)
         }
 
         feedSpectrum(outABL)

--- a/CoreEQ/EQ/RenderObservations.swift
+++ b/CoreEQ/EQ/RenderObservations.swift
@@ -48,6 +48,17 @@ struct RenderObservations {
     var peakLevel: Float = 0
     var clippedSamples = 0
 
+    /// Loudest sample the chain was *handed*, this block and this session.
+    ///
+    /// Without it the output peak cannot be attributed. The system mix is
+    /// Float32 and is not clamped before a tap sees it, so audio can arrive
+    /// above full scale on its own — and at Flat, where every band is identity
+    /// and the trim is unity, CoreEQ passes it through bit for bit. Counting
+    /// that as clipping blamed the app for the material, and told the user to
+    /// lower a preamp that Auto had disabled.
+    var blockSourcePeak: Float = 0
+    var sourcePeakLevel: Float = 0
+
     /// Forgets everything. Called when the engine starts, because every one of
     /// these is a claim about the audio path that is now being rebuilt.
     mutating func reset() {
@@ -55,6 +66,14 @@ struct RenderObservations {
         silentSeconds = 0
         peakLevel = 0
         clippedSamples = 0
+        blockSourcePeak = 0
+        sourcePeakLevel = 0
+    }
+
+    /// The level this block was handed, from `BufferRouter.place`.
+    mutating func note(sourcePeak: Float) {
+        blockSourcePeak = sourcePeak
+        if sourcePeak > sourcePeakLevel { sourcePeakLevel = sourcePeak }
     }
 
     /// Notes a block of input: whether it carried anything, and how much time
@@ -75,13 +94,18 @@ struct RenderObservations {
     /// question is whether this ever happened, and a value that decays answers
     /// it only for whoever is watching at the time.
     mutating func observe(output samples: UnsafePointer<Float>, stride: Int, frames: Int) {
+        // What counts as ours. Above full scale, and above what arrived: a
+        // sample the chain did not lift past the ceiling is the material's to
+        // answer for, not the app's, and saying otherwise sends the user after
+        // a control that will not help.
+        let ceiling = max(1.0, blockSourcePeak)
         var peak = peakLevel
         var clipped = 0
         var index = 0
         for _ in 0..<frames {
             let magnitude = abs(samples[index])
             if magnitude > peak { peak = magnitude }
-            if magnitude > 1.0 { clipped &+= 1 }
+            if magnitude > ceiling { clipped &+= 1 }
             index += stride
         }
         peakLevel = peak

--- a/CoreEQTests/EQ/EQProcessorTests.swift
+++ b/CoreEQTests/EQ/EQProcessorTests.swift
@@ -1452,4 +1452,51 @@ struct EQProcessorTests {
         #expect(processor.observed.clippedSamples == 0)
     }
 
+    // MARK: - Whose clipping is it
+
+    /// The case that exposed this: Flat, Auto, and the warning appeared.
+    ///
+    /// At Flat every band is 0 dB, `Biquad.isActive` maps those to identity and
+    /// the chain skips them, so CoreEQ passes the audio through bit for bit. The
+    /// system mix is Float32 and is not clamped before a tap sees it, so audio
+    /// can arrive above full scale on its own — and counting that blamed the app
+    /// for the material, while advising a preamp that Auto had disabled.
+    @Test func materialThatArrivesTooLoudIsNotTheEqualizersFault() {
+        let processor = makeProcessor()
+        var over = sine(1_000, frames: 2_048, amplitude: 1.0)
+        over = over.map { $0 * 1.4 }
+
+        for _ in 0..<10 { _ = render(processor, over) }
+
+        #expect(processor.observed.sourcePeakLevel > 1.0, "the test signal is not over full scale")
+        #expect(processor.observed.peakLevel > 1.0, "a transparent chain passes it through")
+        #expect(
+            processor.observed.clippedSamples == 0,
+            "the chain added nothing, so it has nothing to answer for")
+    }
+
+    /// And the chain is still held to account for what it does add, even when
+    /// the material was already hot.
+    @Test func aBoostOnTopOfLoudMaterialIsTheEqualizersFault() {
+        let processor = makeProcessor(
+            filters: [EQFilter(kind: .bell, frequency: 1_000, gain: 6, q: 1)])
+        let over = sine(1_000, frames: 2_048, amplitude: 1.0).map { $0 * 1.1 }
+
+        for _ in 0..<10 { _ = render(processor, over) }
+
+        #expect(processor.observed.clippedSamples > 0)
+    }
+
+    /// The report still shows the true output peak, whoever caused it: the
+    /// number a reader needs is what actually left, not what was blamed on the
+    /// app.
+    @Test func thePeakIsTheOutputRegardlessOfBlame() {
+        let processor = makeProcessor()
+        let over = sine(1_000, frames: 2_048, amplitude: 1.0).map { $0 * 1.4 }
+        _ = render(processor, over)
+
+        #expect(abs(processor.observed.peakLevel - 1.4) < 0.05)
+        #expect(abs(processor.observed.sourcePeakLevel - 1.4) < 0.05)
+    }
+
 }

--- a/docs/ROADMAP.org
+++ b/docs/ROADMAP.org
@@ -47,7 +47,34 @@ without guaranteeing clipping away. The mix level arriving at a tap is
 unknowable from inside it. If the noise is also present at Flat, it is not
 clipping and needs a real investigation.
 
-*The report now answers this without a round trip.* The render path keeps the
+*Measured, and attributed — but not shown on screen.* An on-screen warning was
+built and then taken out again. Two things decided it.
+
+The first was accuracy. It counted any output sample above full scale, and so it
+fired at Flat with Auto, which is the default state. At Flat every band is 0 dB,
+which =Biquad.isActive= maps to identity, so the chain is skipped and CoreEQ
+passes audio through bit for bit; the system mix is Float32 and is not clamped
+before a tap sees it, so material arrives over full scale on its own — lossy
+codecs overshoot, resampling reconstructs peaks above the samples that made
+them, and modern masters sit at the ceiling to begin with. The warning was
+blaming the app for the recording, and pointing at a preamp that Auto had
+disabled.
+
+That part is fixed and kept: a sample only counts when the chain lifted it past
+both full scale *and* the level it arrived at, measured where =BufferRouter=
+copies the source, so it costs nothing and reads exactly the samples that become
+the output. The report carries both peaks, and says so when the material itself
+arrived hot.
+
+The second was whether to show it at all. Preventing this is the convention for
+consumer equalizers — AutoEQ ships a preamp with every profile for exactly this
+reason — and CoreEQ already prevents it with =AutoGain=, on by default. A clip
+light is the *professional* convention, and it belongs on an output meter, which
+this app does not have. It would be seen rarely, by users who had never seen it
+before, in an app whose case for existing is that it is simple. So the
+measurement stays and the badge does not.
+
+*The report also answers this without a round trip.* The render path keeps the
 largest magnitude it has produced since the engine started and counts the
 samples that did not fit, and the diagnostics report carries both — =peak
 output: 0.71, no clipping=, or the peak with a count and what to do about it.


### PR DESCRIPTION
Groundwork for the open Bluetooth-noise report, where clipping is the first
hypothesis and the cheapest to rule out.

The render path already counted output samples above full scale, but counting
them alone blames the app for the material. The system mix is Float32 and is not
clamped before a tap sees it, so audio arrives over full scale on its own —
lossy codecs overshoot, resampling reconstructs peaks above the samples that
made them, and modern masters sit at the ceiling already. At Flat every band is
0 dB, which `Biquad.isActive` maps to identity, so CoreEQ passes that through bit
for bit and was reporting it as its own clipping.

A sample now counts only when the chain lifted it past **both** full scale and
the level it arrived at. The source peak is taken where `BufferRouter.place`
copies the audio — free, since that loop already touches exactly the samples that
become the output, and unlike the whole input buffer list it excludes a duplex
device's own microphone input.

The diagnostics report carries both peaks and says when the material itself
arrived hot, so a pasted report now distinguishes "the equalizer is clipping"
from "this recording had no headroom left" without a round trip.

An on-screen warning was built alongside this and removed again: prevention is
the convention for consumer equalizers, `AutoGain` already does it and is on by
default, and a clip light belongs on an output meter this app does not have. The
reasoning is recorded in the roadmap rather than dropped silently.